### PR TITLE
Fix the setup/archive symlinks

### DIFF
--- a/archive
+++ b/archive
@@ -1,1 +1,1 @@
-bin/bookmark-archiver
+bin/archivebox

--- a/bin/bookmark-archiver
+++ b/bin/bookmark-archiver
@@ -1,0 +1,1 @@
+archivebox

--- a/bin/setup-bookmark-archiver
+++ b/bin/setup-bookmark-archiver
@@ -1,0 +1,1 @@
+setup-archivebox

--- a/setup
+++ b/setup
@@ -1,1 +1,1 @@
-bin/setup-bookmark-archiver
+bin/setup-archivebox


### PR DESCRIPTION
Since the README still includes these in the instructions, I guess we should fix these symlinks.