### PR TITLE
return url instead of title if it contains a <

### DIFF
--- a/archivebox/util.py
+++ b/archivebox/util.py
@@ -238,7 +238,7 @@ def fetch_page_title(url, default=True):
             sys.stdout.flush()
         html_content = urllib.request.urlopen(url, timeout=10).read().decode('utf-8')
         match = re.search('<title>(.*?)</title>', html_content)
-        return match.group(1) if match else default or None
+        return match.group(1) if match and '<' not in match.group(1) else default or None
     except Exception:
         if default is False:
             raise


### PR DESCRIPTION
The method fetch_page_title does not return the found title, if that
title contains a left angle bracket. This bracket usually indicates
that an opening tag follows, which we do not want in out title since it
breaks the table in the index.html.

fixes #141

# Summary

This PR changes fetch_page_title to return the url instead of title if title contains a left angle bracket

# Changes these areas

- [ ] Config
- [x] Bugfixes
- [ ] Command line interface
- [ ] Feature behavior
- [ ] Internal design
- [ ] Archived data layout on disk

# Roadmap Goals

This PR helps us move towards ??? roadmap goal, as outlined here: https://github.com/pirate/ArchiveBox#roadmap 
--> roadmap link does not work
