### PR TITLE
Don't run ls if using non-default directory

### DIFF
--- a/bin/archivebox-export-browser-history
+++ b/bin/archivebox-export-browser-history
@@ -6,10 +6,10 @@ mkdir -p "$REPO_DIR/output/sources"
 
 if [[ "$1" == "--chrome" ]]; then
     # Google Chrome / Chromium
-    default=$(ls ~/Library/Application\ Support/Google/Chrome/Default/History)
     if [[ -e "$2" ]]; then
         cp "$2" "$REPO_DIR/output/sources/chrome_history.db.tmp"
     else
+        default=$(ls ~/Library/Application\ Support/Google/Chrome/Default/History)
         echo "Defaulting to history db: $default"
         echo "Optionally specify the path to a different sqlite history database as the 2nd argument."
         cp "$default" "$REPO_DIR/output/sources/chrome_history.db.tmp"
@@ -22,10 +22,10 @@ fi
 
 if [[ "$1" == "--firefox" ]]; then
     # Firefox
-    default=$(ls ~/Library/Application\ Support/Firefox/Profiles/*.default/places.sqlite)
     if [[ -e "$2" ]]; then
         cp "$2" "$REPO_DIR/output/sources/firefox_history.db.tmp"
     else
+        default=$(ls ~/Library/Application\ Support/Firefox/Profiles/*.default/places.sqlite)
         echo "Defaulting to history db: $default"
         echo "Optionally specify the path to a different sqlite history database as the 2nd argument."
         cp "$default" "$REPO_DIR/output/sources/firefox_history.db.tmp"


### PR DESCRIPTION
Previously, an error message would appear if using a non-default directory because it would run `ls` on the non-existent default directory:

```bash
ls: cannot access '/home/nicolas/Library/Application Support/Firefox/Profiles/*.default/places.sqlite': No such file or directory
```

# Summary

This PR fixes an error message that appears when exporting browser history from a non-default directory (such as on Ubuntu, where Firefox data is at `~/.mozilla/firefox/`).

# Changes these areas

- [ ] Config
- [x] Bugfixes
- [ ] Command line interface
- [ ] Feature behavior
- [ ] Internal design
- [ ] Archived data layout on disk
