### PR TITLE
Fix double-download of Chromium binary and backwards symlink in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN git clone https://github.com/pirate/ArchiveBox /home/pptruser/app \
     && chown -R pptruser:pptruser /data \
     && ln -s /data /home/pptruser/app/archivebox/output \
     && ln -s /home/pptruser/app/bin/* /bin/ \
-#    && ln -s /home/pptruser/app/bin/archive /bin/archivebox \
+    # && ln -s /home/pptruser/app/bin/archive /bin/archivebox \
     && chown -R pptruser:pptruser /home/pptruser/app/archivebox
     # && pip3 install -r /home/pptruser/app/archivebox/requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ USER pptruser
 WORKDIR /home/pptruser/app
 
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["/bin/archive"]
+CMD ["/bin/archivebox"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ RUN apt-get update && apt-get install -y wget --no-install-recommends \
 ADD https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 
+# Uncomment to skip the chromium download when installing puppeteer. If you do,
+# you'll need to launch puppeteer with:
+#     browser.launch({executablePath: 'google-chrome-unstable'})
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+
 # Install puppeteer so it's available in the container.
 RUN npm i puppeteer
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN git clone https://github.com/pirate/ArchiveBox /home/pptruser/app \
     && chown -R pptruser:pptruser /data \
     && ln -s /data /home/pptruser/app/archivebox/output \
     && ln -s /home/pptruser/app/bin/* /bin/ \
-    && ln -s /home/pptruser/app/bin/archive /bin/archivebox \
+#    && ln -s /home/pptruser/app/bin/archive /bin/archivebox \
     && chown -R pptruser:pptruser /home/pptruser/app/archivebox
     # && pip3 install -r /home/pptruser/app/archivebox/requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,4 +69,4 @@ USER pptruser
 WORKDIR /home/pptruser/app
 
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["/bin/archivebox"]
+CMD ["/bin/archive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN git clone https://github.com/pirate/ArchiveBox /home/pptruser/app \
     && chown -R pptruser:pptruser /data \
     && ln -s /data /home/pptruser/app/archivebox/output \
     && ln -s /home/pptruser/app/bin/* /bin/ \
-    # && ln -s /home/pptruser/app/bin/archive /bin/archivebox \
+    && ln -s /home/pptruser/app/bin/archivebox /bin/archive \
     && chown -R pptruser:pptruser /home/pptruser/app/archivebox
     # && pip3 install -r /home/pptruser/app/archivebox/requirements.txt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
             - SHOW_PROGRESS=False
         volumes:
             - ./data:/data
-        command: bash -c 'echo "https://github.com/pirate/ArchiveBox" | /bin/archivebox; tail -f /dev/null'
+        command: bash -c 'echo "https://github.com/pirate/ArchiveBox" | /bin/archive; tail -f /dev/null'
 
     nginx:
         image: 'nginx'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
             - SHOW_PROGRESS=False
         volumes:
             - ./data:/data
-        command: bash -c 'echo "https://github.com/pirate/ArchiveBox" | /bin/archive; tail -f /dev/null'
+        command: bash -c 'echo "https://github.com/pirate/ArchiveBox" | /bin/archivebox; tail -f /dev/null'
 
     nginx:
         image: 'nginx'


### PR DESCRIPTION
# Summary

Added env variable to skip puppeteer's downloading of chromium because the Dockerfile already does that and not skipping it results in an error. Also removed a redundant symlinking step since the repo already includes those links

# Changes these areas

- [ ] Config
- [x] Bugfixes
- [ ] Command line interface
- [ ] Feature behavior
- [ ] Internal design
- [ ] Archived data layout on disk
