### PR TITLE
Add API server to provide remote link additions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN git clone https://github.com/pirate/ArchiveBox /home/pptruser/app \
     && chown -R pptruser:pptruser /data \
     && ln -s /data /home/pptruser/app/archivebox/output \
     && ln -s /home/pptruser/app/bin/* /bin/ \
-    && ln -s /home/pptruser/app/bin/archive /bin/archivebox \
+    && ln -s /home/pptruser/app/bin/archivebox /bin/archive \
     && chown -R pptruser:pptruser /home/pptruser/app/archivebox
     # && pip3 install -r /home/pptruser/app/archivebox/requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN git clone https://github.com/pirate/ArchiveBox /home/pptruser/app \
     && chown -R pptruser:pptruser /data \
     && ln -s /data /home/pptruser/app/archivebox/output \
     && ln -s /home/pptruser/app/bin/* /bin/ \
-    && ln -s /home/pptruser/app/bin/archivebox /bin/archive \
+    && ln -s /home/pptruser/app/bin/archive /bin/archivebox \
     && chown -R pptruser:pptruser /home/pptruser/app/archivebox
     # && pip3 install -r /home/pptruser/app/archivebox/requirements.txt
 
@@ -63,5 +63,5 @@ ENV LANG=C.UTF-8 \
 USER pptruser
 WORKDIR /home/pptruser/app
 
-ENTRYPOINT ["/home/pptruser/app/archivebox/api_server.py"]
-#CMD ["/home/pptruser/app/archivebox/api_server.py"]
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["/bin/archive"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -13,7 +13,7 @@ LABEL maintainer="Nick Sweeting <archivebox-git@sweeting.me>"
 
 RUN apt-get update \
     && apt-get install -yq --no-install-recommends \
-        git wget curl youtube-dl gnupg2 libgconf-2-4 python3 python3-pip \
+        git wget curl youtube-dl gnupg2 libgconf-2-4 python3 python3-pip python3-flask \
     && rm -rf /var/lib/apt/lists/*
 
 # Install latest chrome package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
@@ -40,8 +40,8 @@ RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
     && chown -R pptruser:pptruser /node_modules
 
 # Install the ArchiveBox repository and pip requirements
-RUN git clone https://github.com/pirate/ArchiveBox /home/pptruser/app \
-    && mkdir -p /data \
+COPY . /home/pptruser/app
+RUN mkdir -p /data \
     && chown -R pptruser:pptruser /data \
     && ln -s /data /home/pptruser/app/archivebox/output \
     && ln -s /home/pptruser/app/bin/* /bin/ \
@@ -63,5 +63,5 @@ ENV LANG=C.UTF-8 \
 USER pptruser
 WORKDIR /home/pptruser/app
 
-ENTRYPOINT ["/home/pptruser/app/archivebox/api_server.py"]
+ENTRYPOINT ["python3", "-u", "/home/pptruser/app/archivebox/api_server.py"]
 #CMD ["/home/pptruser/app/archivebox/api_server.py"]

--- a/archivebox/api_server.py
+++ b/archivebox/api_server.py
@@ -1,0 +1,33 @@
+
+from flask import Flask
+
+from archive_queue import ArchiveQueue, ArchiveAgent
+
+
+class ApiServer(object):
+    """Api server"""
+
+    def __init__(self):
+        """Create server object"""
+        self.app = Flask('ArchiveBox')
+
+        @self.app.route('/add-link/<string:url>')
+        def add_link(url):
+            """Add link to queue"""
+            ArchiveQueue.add_link_to_queue(url)
+            return url
+
+    def start(self):
+        """Start app"""
+        self.app.run()
+
+
+if __name__ == '__main__':
+    # Create archive agent object and start
+    # daemon
+    ARCHIVE_AGENT = ArchiveAgent.get_instance()
+    ARCHIVE_AGENT.start()
+
+    # Create API server object and start
+    API_SERVER = ApiServer()
+    API_SERVER.start()

--- a/archivebox/api_server.py
+++ b/archivebox/api_server.py
@@ -1,5 +1,9 @@
+# ArchiveBox
+# MatthewJohn 2019 | MIT License
+# https://github.com/matthewjohn/ArchiveBox
 
-from flask import Flask
+
+from flask import Flask, request
 
 from archive_queue import ArchiveQueue, ArchiveAgent
 
@@ -11,18 +15,21 @@ class ApiServer(object):
         """Create server object"""
         self.app = Flask('ArchiveBox')
 
-        @self.app.route('/add-link/<string:url>')
-        def add_link(url):
+        @self.app.route('/add-link')
+        def add_link():
             """Add link to queue"""
-            ArchiveQueue.add_link_to_queue(url)
-            return url
+            url = request.args.get('url')
+            if url:
+                ArchiveQueue.add_link_to_queue(url)
+            return url or 'No link provided'
 
     def start(self):
         """Start app"""
-        self.app.run()
+        self.app.run(host='0.0.0.0')
 
 
 if __name__ == '__main__':
+
     # Create archive agent object and start
     # daemon
     ARCHIVE_AGENT = ArchiveAgent.get_instance()

--- a/archivebox/archive_queue.py
+++ b/archivebox/archive_queue.py
@@ -83,26 +83,32 @@ class ArchiveAgent(Thread):
                 sleep(5)
                 continue
 
-            print('Processing %s' % link)
+            try:
+                print('Processing %s' % link)
 
-            source = save_stdin_source(link)
+                source = save_stdin_source(link)
 
-            # Step 1: Parse the links and dedupe them with existing archive
-            all_links, new_links = load_links(archive_path=out_dir,
-                                              import_path=source)
+                # Step 1: Parse the links and dedupe them with existing archive
+                all_links, new_links = load_links(archive_path=out_dir,
+                                                  import_path=source)
 
-            # Step 2: Write new index
-            write_links_index(out_dir=out_dir, links=all_links)
+                # Step 2: Write new index
+                write_links_index(out_dir=out_dir, links=all_links)
 
-            # Step 3: Run the archive methods for each link
-            if ONLY_NEW:
-                update_archive(out_dir, new_links, source=source,
-                               resume=resume, append=True)
-            else:
-                update_archive(out_dir, all_links, source=source,
-                               resume=resume, append=True)
+                # Step 3: Run the archive methods for each link
+                if ONLY_NEW:
+                    update_archive(out_dir, new_links, source=source,
+                                   resume=resume, append=True)
+                else:
+                    update_archive(out_dir, all_links, source=source,
+                                   resume=resume, append=True)
 
-            # Step 4: Re-write links index with
-            # updated titles, icons, and resources
-            all_links, _ = load_links(archive_path=out_dir)
-            write_links_index(out_dir=out_dir, links=all_links)
+                # Step 4: Re-write links index with
+                # updated titles, icons, and resources
+                all_links, _ = load_links(archive_path=out_dir)
+                write_links_index(out_dir=out_dir, links=all_links)
+
+                print('Processing complete: %s' % link)
+
+            except Exception as exc:
+                print('Exception thrown whilst processing: %s' % str(exc))

--- a/archivebox/archive_queue.py
+++ b/archivebox/archive_queue.py
@@ -1,18 +1,40 @@
+# ArchiveBox
+# MatthewJohn 2019 | MIT License
+# https://github.com/matthewjohn/ArchiveBox
 
+import os
 from threading import Thread
 from time import sleep
+
+from archive import load_links, update_archive
+from index import (
+    write_links_index,
+)
+from config import (
+    ONLY_NEW,
+    OUTPUT_DIR,
+)
+from util import (
+    save_stdin_source,
+    migrate_data,
+)
 
 
 class ArchiveQueue(object):
     """Provide a queueing system between web interface and archiving agent."""
 
-    """List of queued links to be processed."""
+    # List of queued links to be processed.
     QUEUE = []
 
     @classmethod
     def add_link_to_queue(cls, link):
         """Add link to be queued to proccessed."""
         ArchiveQueue.QUEUE.append(link)
+
+    @classmethod
+    def get_link(cls):
+        """Obtain a link, or return None is quee is empty."""
+        return ArchiveQueue.QUEUE.pop(0) if len(ArchiveQueue.QUEUE) else None
 
 
 class ArchiveAgent(Thread):
@@ -26,29 +48,61 @@ class ArchiveAgent(Thread):
 
     @classmethod
     def get_instance(cls):
-        """Return singleton instance of thread"""
+        """Return singleton instance of thread."""
         if cls.INSTANCE is None:
             cls.INSTANCE = cls()
 
         return cls.INSTANCE
 
     def __init__(self):
-        """Store member variable for starting/stopping"""
+        """Store member variable for starting/stopping."""
         self.stop = False
+        super(ArchiveAgent, self).__init__()
 
     def run(self):
-        """Method for thread loop"""
+        """Method for thread loop."""
+
+        migrate_data()
+
+        # See if archive folder [already exists
+        for out_dir in (OUTPUT_DIR, 'bookmarks', 'pocket', 'pinboard', 'html'):
+            if os.path.exists(out_dir):
+                break
+        else:
+            out_dir = OUTPUT_DIR
+        resume = None
+
         # Continue looping until stopped
         while not self.stop:
 
-            # Iterate through list of links in queue.
-            # Use copy, to ensure that altering the queue
-            # whilst iterating does not cause any unwanted
-            # side effects
-            for link in list(ArchiveQueue.QUEUE):
+            link = ArchiveQueue.get_link()
 
-                # Remove link from queue
-                ArchiveQueue.QUEUE.remove(link)
+            if link is None:
+                # If no link is returned, the queue is empty, so
+                # wait and iterate again
+                sleep(5)
+                continue
 
-            # Once complete, sleep for 5 seconds.
-            sleep(5)
+            print('Processing %s' % link)
+
+            source = save_stdin_source(link)
+
+            # Step 1: Parse the links and dedupe them with existing archive
+            all_links, new_links = load_links(archive_path=out_dir,
+                                              import_path=source)
+
+            # Step 2: Write new index
+            write_links_index(out_dir=out_dir, links=all_links)
+
+            # Step 3: Run the archive methods for each link
+            if ONLY_NEW:
+                update_archive(out_dir, new_links, source=source,
+                               resume=resume, append=True)
+            else:
+                update_archive(out_dir, all_links, source=source,
+                               resume=resume, append=True)
+
+            # Step 4: Re-write links index with
+            # updated titles, icons, and resources
+            all_links, _ = load_links(archive_path=out_dir)
+            write_links_index(out_dir=out_dir, links=all_links)

--- a/archivebox/archive_queue.py
+++ b/archivebox/archive_queue.py
@@ -1,0 +1,54 @@
+
+from threading import Thread
+from time import sleep
+
+
+class ArchiveQueue(object):
+    """Provide a queueing system between web interface and archiving agent."""
+
+    """List of queued links to be processed."""
+    QUEUE = []
+
+    @classmethod
+    def add_link_to_queue(cls, link):
+        """Add link to be queued to proccessed."""
+        ArchiveQueue.QUEUE.append(link)
+
+
+class ArchiveAgent(Thread):
+    """Threaded agent to perform archving."""
+
+    # Class variable to store singleton instance.
+    INSTANCE = None
+
+    # Cached reference to 'old links'
+    OLD_LINKS = None
+
+    @classmethod
+    def get_instance(cls):
+        """Return singleton instance of thread"""
+        if cls.INSTANCE is None:
+            cls.INSTANCE = cls()
+
+        return cls.INSTANCE
+
+    def __init__(self):
+        """Store member variable for starting/stopping"""
+        self.stop = False
+
+    def run(self):
+        """Method for thread loop"""
+        # Continue looping until stopped
+        while not self.stop:
+
+            # Iterate through list of links in queue.
+            # Use copy, to ensure that altering the queue
+            # whilst iterating does not cause any unwanted
+            # side effects
+            for link in list(ArchiveQueue.QUEUE):
+
+                # Remove link from queue
+                ArchiveQueue.QUEUE.remove(link)
+
+            # Once complete, sleep for 5 seconds.
+            sleep(5)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,9 @@ services:
 
     # Uncomment the below to enable an API to add URLs
     #api:
-    #    build: .
-    #    dockerfile: Dockerfile.api
+    #    build:
+    #        context: .
+    #        dockerfile: Dockerfile.api
     #    ports:
     #        - '8099:5000'
     #    environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,19 @@
 version: '3'
 
 services:
+
+    # Uncomment the below to enable an API to add URLs
+    #api:
+    #    build: .
+    #    dockerfile: Dockerfile.api
+    #    ports:
+    #        - '8099:5000'
+    #    environment:
+    #        - USE_COLOR=False
+    #        - SHOW_PROGRESS=False
+    #    volumes:
+    #        - ./data:/data
+
     archivebox:
         build: .
         stdin_open: true


### PR DESCRIPTION
# Summary

This PR add the ability to do run an API server instead of a single run of the archiver, allowing user to post new URLs to index: e.g.:

    http://localhost:8099/add-link?url=https://github.com/

This then gets added to a queue and a thread picks up the new URLs and processes them

# Changes these areas

- [ ] Config
- [ ] Bugfixes
- [ ] Command line interface
- [X] Feature behavior
- [X] Internal design
- [ ] Archived data layout on disk

# Roadmap Goals

This PR helps us move towards 'add an optional web GUI for managing sources, adding new links, and viewing the archive' roadmap goal, as outlined here: https://github.com/pirate/ArchiveBox#roadmap
