### PR TITLE
wget: Remove unsupported compression option

### DIFF
--- a/archivebox/archive_methods.py
+++ b/archivebox/archive_methods.py
@@ -33,6 +33,7 @@ from config import (
     WGET_USER_AGENT,
     CHECK_SSL_VALIDITY,
     COOKIES_FILE,
+    WGET_AUTO_COMPRESSION
 )
 from util import (
     domain,
@@ -227,6 +228,7 @@ def fetch_wget(link_dir, link, timeout=TIMEOUT):
         '-e', 'robots=off',
         '--restrict-file-names=unix',
         '--timeout={}'.format(timeout),
+        *(('--compression=auto',) if WGET_AUTO_COMPRESSION else ()),
         *(() if FETCH_WARC else ('--timestamping',)),
         *(('--warc-file={}'.format(warc_path),) if FETCH_WARC else ()),
         *(('--page-requisites',) if FETCH_WGET_REQUISITES else ()),

--- a/archivebox/archive_methods.py
+++ b/archivebox/archive_methods.py
@@ -224,7 +224,6 @@ def fetch_wget(link_dir, link, timeout=TIMEOUT):
         '--backup-converted',
         '--span-hosts',
         '--no-parent',
-        '--compression=auto',
         '-e', 'robots=off',
         '--restrict-file-names=unix',
         '--timeout={}'.format(timeout),

--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -72,6 +72,7 @@ TEMPLATES_DIR = os.path.join(PYTHON_PATH, 'templates')
 CHROME_SANDBOX = os.getenv('CHROME_SANDBOX', 'True').lower() == 'true'
 USE_CHROME = FETCH_PDF or FETCH_SCREENSHOT or FETCH_DOM
 USE_WGET = FETCH_WGET or FETCH_WGET_REQUISITES or FETCH_WARC
+WGET_AUTO_COMPRESSION =   not run([WGET_BINARY, "--compression=auto", "--help"], stdout=DEVNULL).returncode
 
 ########################### Environment & Dependencies #########################
 

--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -72,7 +72,7 @@ TEMPLATES_DIR = os.path.join(PYTHON_PATH, 'templates')
 CHROME_SANDBOX = os.getenv('CHROME_SANDBOX', 'True').lower() == 'true'
 USE_CHROME = FETCH_PDF or FETCH_SCREENSHOT or FETCH_DOM
 USE_WGET = FETCH_WGET or FETCH_WGET_REQUISITES or FETCH_WARC
-WGET_AUTO_COMPRESSION =   not run([WGET_BINARY, "--compression=auto", "--help"], stdout=DEVNULL).returncode
+WGET_AUTO_COMPRESSION = USE_WGET and WGET_BINARY and (not run([WGET_BINARY, "--compression=auto", "--help"], stdout=DEVNULL).returncode)
 
 ########################### Environment & Dependencies #########################
 


### PR DESCRIPTION
# Summary
`--compression=auto` is not supported on Raspberry Pis. This PR removes it from ArchiveBox.

See https://unix.stackexchange.com/questions/464372/how-could-compression-be-missing-from-my-wget for more information.

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
