### PR TITLE
util.py: Don't use regular expressions to parse HTML

### DIFF
--- a/archivebox/util.py
+++ b/archivebox/util.py
@@ -193,12 +193,14 @@ def fetch_page_title(url, timeout=10, progress=SHOW_PROGRESS):
         if progress:
             sys.stdout.write('.')
             sys.stdout.flush()
-
-        html = download_url(url, timeout=timeout)
-        document = lxml.html.parse(html)
         
-        result = document.find(".//title")
-        return result.text.strip() if result else None
+        html = download_url(url, timeout=timeout)
+        document = lxml.html.fromstring(html)
+        result = document.xpath(".//title")
+        if len(result) == 0:
+            return None
+        
+        return result[0].text.strip()
     except Exception as err:  # noqa
         # print('[!] Failed to fetch title because of {}: {}'.format(
         #     err.__class__.__name__,


### PR DESCRIPTION
# Summary
Regexes should never be used to parse HTML ([source](http://htmlparsing.com/regexes.html), and [another](https://stackoverflow.com/a/590789/1460422)).

This commit fixes the <title /> finding logic to use a full HTML parser instead.

Example URL that now works under the new system: https://css-tricks.com/snippets/css/complete-guide-grid/

Screenshot:
![image](https://user-images.githubusercontent.com/9929737/55027239-b2b3ee00-4ffc-11e9-9339-731210a869e7.png)


# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
