### PR TITLE
Add an option to skip links that are broken.

### DIFF
--- a/archivebox/config.py
+++ b/archivebox/config.py
@@ -48,6 +48,7 @@ YOUTUBEDL_BINARY =       os.getenv('YOUTUBEDL_BINARY',       'youtube-dl')
 CHROME_BINARY =          os.getenv('CHROME_BINARY',          None)
 
 URL_BLACKLIST =          os.getenv('URL_BLACKLIST',          None)
+SKIP_BROKEN_LINKS =      os.getenv('SKIP_BROKEN_LINKS',      'False'            ).lower() == 'true'
 
 try:
     OUTPUT_DIR = os.path.abspath(os.getenv('OUTPUT_DIR'))


### PR DESCRIPTION
# Summary
I think it is nice if ArchiveBox can be configured to not create index entry for non-existent pages. I don't particularly care how it's done, just that it's possible. This patch shows one approach. I didn't change the default behavior. 
 
# Changes these areas

- [ ] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [X] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk