### PR TITLE
Copy project into image instead of cloning to avoid stale images on Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ RUN groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
     && chown -R pptruser:pptruser /node_modules
 
 # Install the ArchiveBox repository and pip requirements
-RUN git clone https://github.com/pirate/ArchiveBox /home/pptruser/app \
-    && mkdir -p /data \
+COPY . /home/pptruser/app
+RUN mkdir -p /data \
     && chown -R pptruser:pptruser /data \
     && ln -s /data /home/pptruser/app/archivebox/output \
     && ln -s /home/pptruser/app/bin/* /bin/ \


### PR DESCRIPTION
Docker `RUN` statements cache based on the text of the command executed,
not the content of what it does to the image.

Since the command was cloning the project, and the text didn't change,
building the image would not update the code if the image was already
cached. This lead to a stale Docker image distributed on Docker Hub.

This could also cause some confusion, as modified code would not show up
on the image during the build process.

This commit changes the build process to copy the content of the project
into the image. Whenever a file changes it will trigger a new updated
image.

**IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes, I will close them with great prejudice.  The PEP8 checks I don't follow are intentional. PRs for minor bugfixes, typos, etc are fine.**

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
