### PR TITLE
Archive Method: Add Firefox for full page screenshots

### DIFF
--- a/archivebox/archive_methods.py
+++ b/archivebox/archive_methods.py
@@ -33,7 +33,9 @@ from config import (
     WGET_USER_AGENT,
     CHECK_SSL_VALIDITY,
     COOKIES_FILE,
-    WGET_AUTO_COMPRESSION
+    WGET_AUTO_COMPRESSION,
+    CHROME_AVAILABLE,
+    FIREFOX_AVAILABLE,
 )
 from util import (
     domain,
@@ -46,6 +48,7 @@ from util import (
     chmod_file,
     wget_output_path,
     chrome_args,
+    firefox_args,
     check_link_structure,
     run, PIPE, DEVNULL
 )
@@ -339,11 +342,18 @@ def fetch_screenshot(link_dir, link, timeout=TIMEOUT):
     """take screenshot of site using chrome --headless"""
 
     output = 'screenshot.png'
-    cmd = [
-        *chrome_args(TIMEOUT=timeout),
-        '--screenshot',
-        link['url'],
-    ]
+    if CHROME_AVAILABLE:
+        cmd = [
+            *chrome_args(TIMEOUT=timeout),
+            '--screenshot',
+            link['url'],
+        ]
+    elif FIREFOX_AVAILABLE:
+        cmd = [
+            *firefox_args(),
+            '--screenshot',
+            link['url'],
+        ]
     status = 'succeeded'
     timer = TimedProgress(timeout, prefix='      ')
     try:

--- a/archivebox/util.py
+++ b/archivebox/util.py
@@ -30,6 +30,7 @@ from config import (
     CHECK_SSL_VALIDITY,
     WGET_USER_AGENT,
     CHROME_OPTIONS,
+    FIREFOX_OPTIONS,
 )
 from logs import pretty_path
 
@@ -567,4 +568,22 @@ def chrome_args(**options):
     if options['CHROME_USER_DATA_DIR']:
         cmd_args.append('--user-data-dir={}'.format(options['CHROME_USER_DATA_DIR']))
     
+    return cmd_args
+
+def firefox_args(**options):
+    """helper to build up a firefox shell command with arguments"""
+
+    options = {**FIREFOX_OPTIONS, **options}
+
+    cmd_args = [options['FIREFOX_BINARY']]
+
+    if options['FIREFOX_HEADLESS']:
+        cmd_args += ('--headless',)
+
+    if options['FIREFOX_PROFILE']:
+        cmd_args += ('-P', options['FIREFOX_PROFILE'])
+    
+    if options['FIREFOX_RESOLUTION']:
+        cmd_args += ('--window-size={}'.format(options['FIREFOX_RESOLUTION']),)
+
     return cmd_args


### PR DESCRIPTION
# Summary

This PRs adds firefox support for full page screenshots! Firefox has the advantage of taking the screenshots of the whole page, independent of the viewport size.

**Related issues: #70,  #80, #14**

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [X] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

Unfortunately, the user must make the profile to be used manually, either with `firefox --createProfile ArchiveBox` or by going to about:profiles and selecting "Create a New Profile". A separate profile is needed because firefox doesn't allow the default instance to be opened in the same profile at the same time as the headless instance. Creating a profile could be automated, but the proccess involves reading profiles.ini (and well, modifying user profiles) which I'm not sure is at the scope of this project.