### PR TITLE
Update timestamp in index after a new snapshot is made.

### DIFF
--- a/archivebox/index.py
+++ b/archivebox/index.py
@@ -178,6 +178,7 @@ def patch_links_index(link, out_dir=OUTPUT_DIR):
     for saved_link in json_file_links:
         if saved_link['url'] == link['url']:
             saved_link['title'] = title
+            saved_link['timestamp'] = link['timestamp']
             saved_link['history'] = link['history']
             changed = True
             break


### PR DESCRIPTION
# Summary

After a recent archive run that was somehow borked, I found archive in a
state where index was linking to a directory which didn't exist in archive.
When I tried to archive the link again, it was successful but the index
entry continued to point to the old timestamp, therefore the old
(non-existent) directory.

I think it makes sense to update the timestamp after making a new snapshot,
so that index points to the latest files.

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk