### PR TITLE
Fix json export date parsing

### DIFF
--- a/archivebox/parse.py
+++ b/archivebox/parse.py
@@ -103,7 +103,7 @@ def parse_json_export(json_file):
 
     json_file.seek(0)
     links = json.load(json_file)
-    json_date = lambda s: datetime.strptime(s, '%Y-%m-%dT%H:%M:%S%z')
+    json_date = lambda s: datetime.strptime(s, '%Y-%m-%dT%H:%M:%SZ')
 
     for link in links:
         # example line


### PR DESCRIPTION
# Summary

The format string for `datetime.strptime` did not match the example line in the code comment: https://github.com/pirate/ArchiveBox/blob/58c9b47d433b5ef68d5fd8fa510e2bd37aff60ba/archivebox/parse.py#L109-L110
since `%z` matches ["UTC offset in the form ±HHMM"](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior).  It also doesn't work with the actual json exported from pinboard, and I've verified that this fixes it.

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk