### PR TITLE
Fix a leaking file descriptor.

### DIFF
--- a/archivebox/index.py
+++ b/archivebox/index.py
@@ -187,7 +187,7 @@ def patch_links_index(link, out_dir=OUTPUT_DIR):
     # Patch HTML index
     html_path = os.path.join(out_dir, 'index.html')
     with open(html_path, 'r') as html_file:
-        html = [line[:-1] for line in html_file]
+        html = html_file.read().splitlines()
     for idx, line in enumerate(html):
         if title and ('<span data-title-for="{}"'.format(link['url']) in line):
             html[idx] = '<span>{}</span>'.format(title)

--- a/archivebox/index.py
+++ b/archivebox/index.py
@@ -186,7 +186,8 @@ def patch_links_index(link, out_dir=OUTPUT_DIR):
 
     # Patch HTML index
     html_path = os.path.join(out_dir, 'index.html')
-    html = open(html_path, 'r').read().split('\n')
+    with open(html_path, 'r') as html_file:
+        html = [line[:-1] for line in html_file]
     for idx, line in enumerate(html):
         if title and ('<span data-title-for="{}"'.format(link['url']) in line):
             html[idx] = '<span>{}</span>'.format(title)


### PR DESCRIPTION
# Summary

Handles a `ResourceWarning` on Py3, and generally not leaking FDs especially on non-CPython.

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk