### PR TITLE
Add shebang to script file

### DIFF
--- a/bin/archivebox
+++ b/bin/archivebox
@@ -1,1 +1,3 @@
+#!/bin/sh
+
 ../archivebox/archive.py


### PR DESCRIPTION
Execution scripts without shebang cause cause "exec format error" in docker and elsewhere.
More info:
- https://www.lewuathe.com/exec-format-error-in-docker-container.html
- https://stackoverflow.com/a/12911604

Fixes #243 