### PR TITLE
Bug fix with youtube-dl option

### DIFF
--- a/archivebox/archive_methods.py
+++ b/archivebox/archive_methods.py
@@ -496,7 +496,6 @@ def fetch_media(link_dir, link, timeout=MEDIA_TIMEOUT):
         '--write-thumbnail',
         '--no-call-home',
         '--no-check-certificate',
-        '--user-agent',
         '--all-subs',
         '--extract-audio',
         '--keep-video',
@@ -563,7 +562,7 @@ def archive_dot_org(link_dir, link, timeout=TIMEOUT):
         CURL_BINARY,
         '--location',
         '--head',
-	*(('--user-agent', '{}'.format(CURL_USER_AGENT),) if CURL_USER_AGENT else ()),  # be nice to the Archive.org people and show them where all this ArchiveBox traffic is coming from
+        *(('--user-agent', '{}'.format(CURL_USER_AGENT),) if CURL_USER_AGENT else ()),  # be nice to the Archive.org people and show them where all this ArchiveBox traffic is coming from
         '--max-time', str(timeout),
         *(() if CHECK_SSL_VALIDITY else ('--insecure',)),
         submit_url,


### PR DESCRIPTION
# Summary
I find a mistake in this program. When I use youtube-dl in archivebox, I receive:
"User-Agent": "--all-subs"
By default in youtube-dl, the user agent looks good:
   youtube-dl --dump-user-agent
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.45 Safari/537.36
I fix this bug. Also I replace extra tab with spaces.

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

