### PR TITLE
Fix example in Dockerfile. The source for a mount must be absolute.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Usage:
 #     docker build github.com/pirate/ArchiveBox -t archivebox
 #     echo 'https://example.com' | docker run -i --mount type=bind,source=$PWD/data,target=/data archivebox /bin/archive
-#     docker run --mount type=bind,source=$PWD/data,target=/data archivebox /bin/archive 'https://example.com/some/rss/feed.xml'
+#     docker run -v ./data:/data archivebox /bin/archive 'https://example.com/some/rss/feed.xml'
 # Documentation:
 #     https://github.com/pirate/ArchiveBox/wiki/Docker#docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #     - ArchiveBox
 # Usage:
 #     docker build github.com/pirate/ArchiveBox -t archivebox
-#     echo 'https://example.com' | docker run -i --mount type=bind,source=$PWD/data,target=/data archivebox /bin/archive
+#     echo 'https://example.com' | docker run -i -v ./data:/data archivebox /bin/archive
 #     docker run -v ./data:/data archivebox /bin/archive 'https://example.com/some/rss/feed.xml'
 # Documentation:
 #     https://github.com/pirate/ArchiveBox/wiki/Docker#docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 #     - ArchiveBox
 # Usage:
 #     docker build github.com/pirate/ArchiveBox -t archivebox
-#     echo 'https://example.com' | docker run -i --mount type=bind,source=./data,target=/data archivebox /bin/archive
-#     docker run --mount type=bind,source=./data,target=/data archivebox /bin/archive 'https://example.com/some/rss/feed.xml'
+#     echo 'https://example.com' | docker run -i --mount type=bind,source=$PWD/data,target=/data archivebox /bin/archive
+#     docker run --mount type=bind,source=$PWD/data,target=/data archivebox /bin/archive 'https://example.com/some/rss/feed.xml'
 # Documentation:
 #     https://github.com/pirate/ArchiveBox/wiki/Docker#docker
 


### PR DESCRIPTION
# Summary

This PR fixes the examples in the Docker-file.
It is not possible to mount using relative paths in Docker, so
SRC=./data will never work.

