### PR TITLE
Allow feed loading from the add links view

### DIFF
--- a/archivebox/core/forms.py
+++ b/archivebox/core/forms.py
@@ -1,0 +1,7 @@
+from django import forms
+
+CHOICES = (('url', 'URL'), ('feed', 'Feed'))
+
+class AddLinkForm(forms.Form):
+    url = forms.URLField()
+    source = forms.ChoiceField(choices=CHOICES, widget=forms.RadioSelect, initial='url')

--- a/archivebox/themes/default/add_links.html
+++ b/archivebox/themes/default/add_links.html
@@ -159,6 +159,12 @@
             .title-col a {
                 color: black;
             }
+            .ul-form {
+                list-style: none;
+            }
+            .ul-form li {
+                list-style: none;
+            }
         </style>
         <link rel="stylesheet" href="{% static 'bootstrap.min.css' %}">
         <link rel="stylesheet" href="{% static 'jquery.dataTables.min.css' %}"/>
@@ -199,9 +205,9 @@
         <center>
             {{ stdout | safe }}
             <br/><br/>
-            <form action="?" method="POST">{% csrf_token %}
+            <form action="?" method="POST" class="ul-form">{% csrf_token %}
                 Add new links...<br/>
-                <input type="text" name="url" placeholder="URL of page or feed..."/><br/>
+                {{ form.as_ul }}
                 <button role="submit">Add</button>
             </form>
         </center>


### PR DESCRIPTION
# Summary

Move the add links form to a proper django form. Add a new field to select the data source (url or feed). Long requests will probably break, and some proper asynchronous task handling will be required at some point, but this enables the user to load their feeds via the web interface.

# Changes these areas

- [ ] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
