### PR TITLE
Depth flag

### DIFF
--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -49,11 +49,11 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         "--depth",
         action="store",
         default=0,
+        choices=[0,1],
         type=int,
         help="Recursively archive all linked pages up to this many hops away"
     )
     command = parser.parse_args(args or ())
-    #import_str = accept_stdin(stdin)
     add(
         import_str=command.import_path,
         import_path=None,

--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -10,7 +10,7 @@ from typing import List, Optional, IO
 
 from ..main import add, docstring
 from ..config import OUTPUT_DIR, ONLY_NEW
-from .logging import SmartFormatter, accept_stdin
+from .logging import SmartFormatter, reject_stdin
 
 
 @docstring(add.__doc__)
@@ -38,9 +38,10 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         type=str,
         default=None,
         help=(
-            'URL or path to local file containing a list of links to import. e.g.:\n'
+            'URL or path to local file containing a page or list of links to import. e.g.:\n'
             '    https://getpocket.com/users/USERNAME/feed/all\n'
             '    https://example.com/some/rss/feed.xml\n'
+            '    https://example.com\n'
             '    ~/Downloads/firefox_bookmarks_export.html\n'
             '    ~/Desktop/sites_list.csv\n'
         )
@@ -54,6 +55,7 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         help="Recursively archive all linked pages up to this many hops away"
     )
     command = parser.parse_args(args or ())
+    reject_stdin(__command__, stdin)
     add(
         import_str=command.import_path,
         import_path=None,

--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -38,7 +38,7 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         type=str,
         default=None,
         help=(
-            'URL or path to local file containing a page or list of links to import. e.g.:\n'
+            'URL or path to local file to start the archiving process from. e.g.:\n'
             '    https://getpocket.com/users/USERNAME/feed/all\n'
             '    https://example.com/some/rss/feed.xml\n'
             '    https://example.com\n'

--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -68,20 +68,12 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         import_path = command.import_path
 
     add(
-        import_str=import_path,
-        import_path=None,
+        url=import_path,
+        depth=command.depth,
         update_all=command.update_all,
         index_only=command.index_only,
         out_dir=pwd or OUTPUT_DIR,
     )
-    if command.depth == 1:
-        add(
-            import_str=None,
-            import_path=import_path,
-            update_all=command.update_all,
-            index_only=command.index_only,
-            out_dir=pwd or OUTPUT_DIR,
-        )
 
 
 if __name__ == '__main__':

--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -53,14 +53,22 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         help="Recursively archive all linked pages up to this many hops away"
     )
     command = parser.parse_args(args or ())
-    import_str = accept_stdin(stdin)
+    #import_str = accept_stdin(stdin)
     add(
-        import_str=import_str,
-        import_path=command.import_path,
+        import_str=command.import_path,
+        import_path=None,
         update_all=command.update_all,
         index_only=command.index_only,
         out_dir=pwd or OUTPUT_DIR,
     )
+    #if command.depth == 1:
+    #    add(
+    #        import_str=None,
+    #        import_path=command.import_path,
+    #        update_all=command.update_all,
+    #        index_only=command.index_only,
+    #        out_dir=pwd or OUTPUT_DIR,
+    #    )
 
 
 if __name__ == '__main__':

--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -61,14 +61,14 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
         index_only=command.index_only,
         out_dir=pwd or OUTPUT_DIR,
     )
-    #if command.depth == 1:
-    #    add(
-    #        import_str=None,
-    #        import_path=command.import_path,
-    #        update_all=command.update_all,
-    #        index_only=command.index_only,
-    #        out_dir=pwd or OUTPUT_DIR,
-    #    )
+    if command.depth == 1:
+        add(
+            import_str=None,
+            import_path=command.import_path,
+            update_all=command.update_all,
+            index_only=command.index_only,
+            out_dir=pwd or OUTPUT_DIR,
+        )
 
 
 if __name__ == '__main__':

--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -45,6 +45,13 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
             '    ~/Desktop/sites_list.csv\n'
         )
     )
+    parser.add_argument(
+        "--depth",
+        action="store",
+        default=0,
+        type=int,
+        help="Recursively archive all linked pages up to this many hops away"
+    )
     command = parser.parse_args(args or ())
     import_str = accept_stdin(stdin)
     add(
@@ -62,12 +69,6 @@ if __name__ == '__main__':
 
 # TODO: Implement these
 #
-# parser.add_argument(
-#     '--depth', #'-d',
-#     type=int,
-#     help='Recursively archive all linked pages up to this many hops away',
-#     default=0,
-# )
 # parser.add_argument(
 #     '--mirror', #'-m',
 #     action='store_true',

--- a/archivebox/core/views.py
+++ b/archivebox/core/views.py
@@ -66,12 +66,10 @@ class AddLinks(View):
         if form.is_valid():
             url = form.cleaned_data["url"]
             print(f'[+] Adding URL: {url}')
-            if form.cleaned_data["source"] == "url":
-                key = "import_str"
-            else:
-                key = "import_path"
+            depth = 0 if form.cleaned_data["source"] == "url" else 1
             input_kwargs = {
-                key: url,
+                "url": url,
+                "depth": depth,
                 "update_all": False,
                 "out_dir": OUTPUT_DIR,
             }

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -507,8 +507,7 @@ def add(import_str: Optional[str]=None,
 
     if (import_str and import_path) or (not import_str and not import_path):
         stderr(
-            '[X] You should pass either an import path as an argument, '
-            'or pass a list of links via stdin, but not both.\n',
+            '[X] You should pass an import path or a page url as an argument\n',
             color='red',
         )
         raise SystemExit(2)

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -496,8 +496,8 @@ def status(out_dir: str=OUTPUT_DIR) -> None:
 
 
 @enforce_types
-def add(import_str: Optional[str]=None,
-        import_path: Optional[str]=None,
+def add(url: str,
+        depth: int=0,
         update_all: bool=not ONLY_NEW,
         index_only: bool=False,
         out_dir: str=OUTPUT_DIR) -> List[Link]:
@@ -505,17 +505,9 @@ def add(import_str: Optional[str]=None,
 
     check_data_folder(out_dir=out_dir)
 
-    if (import_str and import_path) or (not import_str and not import_path):
-        stderr(
-            '[X] You should pass an import path or a page url as an argument\n',
-            color='red',
-        )
-        raise SystemExit(2)
-    elif import_str:
-        import_path = save_stdin_to_sources(import_str, out_dir=out_dir)
-    elif import_path:
-        import_path = save_file_to_sources(import_path, out_dir=out_dir)
-
+    base_path = save_stdin_to_sources(url, out_dir=out_dir)
+    if depth == 1:
+        depth_path = save_file_to_sources(url, out_dir=out_dir)
     check_dependencies()
 
     # Step 1: Load list of links from the existing index
@@ -523,8 +515,11 @@ def add(import_str: Optional[str]=None,
     all_links: List[Link] = []
     new_links: List[Link] = []
     all_links = load_main_index(out_dir=out_dir)
-    if import_path:
-        all_links, new_links = import_new_links(all_links, import_path, out_dir=out_dir)
+    all_links, new_links = import_new_links(all_links, base_path, out_dir=out_dir)
+    if depth == 1:
+        all_links, new_links_depth = import_new_links(all_links, depth_path, out_dir=out_dir)
+        new_links = new_links + new_links_depth
+
 
     # Step 2: Write updated index with deduped old and new links back to disk
     write_main_index(links=all_links, out_dir=out_dir)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,10 @@
+import os
+import subprocess
+
+import pytest
+
+@pytest.fixture
+def process(tmp_path):
+    os.chdir(tmp_path)
+    process = subprocess.run(['archivebox', 'init'], capture_output=True)
+    return process

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,0 +1,7 @@
+import subprocess
+
+from .fixtures import *
+
+def test_depth_flag_is_accepted(tmp_path, process):
+    arg_process = subprocess.run(["archivebox", "add", "https://example.com", "--depth=0"], capture_output=True)
+    assert 'unrecognized arguments: --depth' not in arg_process.stderr.decode('utf-8')

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,7 +1,15 @@
 import subprocess
+import json
 
 from .fixtures import *
 
-def test_depth_flag_is_accepted(tmp_path, process):
+def test_depth_flag_is_accepted(process):
     arg_process = subprocess.run(["archivebox", "add", "https://example.com", "--depth=0"], capture_output=True)
     assert 'unrecognized arguments: --depth' not in arg_process.stderr.decode('utf-8')
+
+def test_depth_flag_0_crawls_only_the_arg_page(tmp_path, process):
+    arg_process = subprocess.run(["archivebox", "add", "https://example.com", "--depth=0"], capture_output=True)
+    archived_item_path = list(tmp_path.glob('archive/**/*'))[0]
+    with open(archived_item_path / "index.json", "r") as f:
+        output_json = json.load(f)
+    assert output_json["base_url"] == "example.com"

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -13,3 +13,10 @@ def test_depth_flag_0_crawls_only_the_arg_page(tmp_path, process):
     with open(archived_item_path / "index.json", "r") as f:
         output_json = json.load(f)
     assert output_json["base_url"] == "example.com"
+
+def test_depth_flag_1_crawls_the_page_AND_links(tmp_path, process):
+    arg_process = subprocess.run(["archivebox", "add", "https://example.com", "--depth=1"], capture_output=True)
+    with open(tmp_path / "index.json", "r") as f:
+        archive_file = f.read()
+    assert "https://example.com" in archive_file
+    assert "https://www.iana.org/domains/example" in archive_file

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -5,7 +5,13 @@ from .fixtures import *
 
 def test_depth_flag_is_accepted(process):
     arg_process = subprocess.run(["archivebox", "add", "https://example.com", "--depth=0"], capture_output=True)
-    assert 'unrecognized arguments: --depth' not in arg_process.stderr.decode('utf-8')
+    assert 'unrecognized arguments: --depth' not in arg_process.stderr.decode("utf-8")
+
+def test_depth_flag_fails_if_it_is_not_0_or_1(process):
+    arg_process = subprocess.run(["archivebox", "add", "https://example.com", "--depth=5"], capture_output=True)
+    assert 'invalid choice' in arg_process.stderr.decode("utf-8")
+    arg_process = subprocess.run(["archivebox", "add", "https://example.com", "--depth=-1"], capture_output=True)
+    assert 'invalid choice' in arg_process.stderr.decode("utf-8")
 
 def test_depth_flag_0_crawls_only_the_arg_page(tmp_path, process):
     arg_process = subprocess.run(["archivebox", "add", "https://example.com", "--depth=0"], capture_output=True)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,14 +6,7 @@ import subprocess
 from pathlib import Path
 import json
 
-import pytest
-
-@pytest.fixture
-def process(tmp_path):
-    os.chdir(tmp_path)
-    process = subprocess.run(['archivebox', 'init'], capture_output=True)
-    return process
-
+from .fixtures import *
 
 def test_init(tmp_path, process):
     assert "Initializing a new ArchiveBox collection in this folder..." in process.stdout.decode("utf-8")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -31,9 +31,15 @@ def test_add_link(tmp_path, process):
         output_html = f.read()
     assert "Example Domain" in output_html
 
-def test_add_link_does_not_support_stdin(tmp_path, process):
+def test_add_link_support_stdin(tmp_path, process):
     os.chdir(tmp_path)
     stdin_process = subprocess.Popen(["archivebox", "add"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    output = stdin_process.communicate(input="example.com".encode())[0]
-    assert "does not accept stdin" in output.decode("utf-8")
+    stdin_process.communicate(input="http://example.com".encode())
+    archived_item_path = list(tmp_path.glob('archive/**/*'))[0]
+
+    assert "index.json" in [x.name for x in archived_item_path.iterdir()]
+
+    with open(archived_item_path / "index.json", "r") as f:
+        output_json = json.load(f)
+    assert "Example Domain" == output_json['history']['title'][0]['output']
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -31,3 +31,9 @@ def test_add_link(tmp_path, process):
         output_html = f.read()
     assert "Example Domain" in output_html
 
+def test_add_link_does_not_support_stdin(tmp_path, process):
+    os.chdir(tmp_path)
+    stdin_process = subprocess.Popen(["archivebox", "add"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    output = stdin_process.communicate(input="example.com".encode())[0]
+    assert "does not accept stdin" in output.decode("utf-8")
+

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -25,9 +25,9 @@ def test_add_link(tmp_path, process):
 
     with open(archived_item_path / "index.json", "r") as f:
         output_json = json.load(f)
-    assert "IANA — IANA-managed Reserved Domains" == output_json['history']['title'][0]['output']
+    assert "Example Domain" == output_json['history']['title'][0]['output']
 
     with open(tmp_path / "index.html", "r") as f:
         output_html = f.read()
-    assert "IANA — IANA-managed Reserved Domains" in output_html
+    assert "Example Domain" in output_html
 


### PR DESCRIPTION
# Summary

This PR adds the `--depth` flag. The api changes a little with this.

Before: `page | archivebox add`
After: `archivebox add page`

Before: `archivebox add feed`
After `archivebox add feed --depth=1`

There is a slight difference in the second case. Now, the feed page is archived too, as opposed to archiving only the found links.

# Changes these areas

- [ ] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

