### PR TITLE
fix: Create user home to avoid warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 # Run everything from here on out as non-privileged user
 RUN groupadd --system archivebox \
-    && useradd --system --gid archivebox --groups audio,video archivebox
+    && useradd --system --create-home --gid archivebox --groups audio,video archivebox
 
 ADD . "$CODE_PATH"
 WORKDIR "$CODE_PATH"


### PR DESCRIPTION
# Summary

When trying to run the container, I was getting the following error:
```
mkdir: cannot create directory ‘/home/archivebox’: Permission denied
touch: cannot touch '/home/archivebox/.local/share/applications/mimeapps.list': No such file or directory
```

I added the flag to create a home directory during the build step, so this warning does not show up.

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
