### PR TITLE
fix: timestamp comparison in from_json function

### DIFF
--- a/archivebox/index/schema.py
+++ b/archivebox/index/schema.py
@@ -190,7 +190,10 @@ class Link:
             for key, val in json_info.items()
             if key in cls.field_names()
         }
-        info['updated'] = parse_date(info.get('updated'))
+        try:
+            info['updated'] = int(parse_date(info.get('updated'))) # Cast to int which comes with rounding down
+        except (ValueError, TypeError):
+            info['updated'] = None
         info['sources'] = info.get('sources') or []
 
         json_history = info.get('history') or {}


### PR DESCRIPTION
# Summary

Fixes issue with updated date with loading items from_json by casting as int or setting it as `None`

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
