### PR TITLE
feat: Add canonical link http header to the static response

### DIFF
--- a/archivebox/core/views.py
+++ b/archivebox/core/views.py
@@ -107,7 +107,9 @@ class LinkDetails(View):
         # slug is a timestamp
         by_ts = {page.timestamp: page for page in all_pages}
         try:
-            return static.serve(request, archivefile, by_ts[slug].link_dir, show_indexes=True)
+            response = static.serve(request, archivefile, by_ts[slug].link_dir, show_indexes=True)
+            response["Link"] = f'<{by_ts[slug].url}>; rel="canonical"'
+            return response
         except KeyError:
             pass
 


### PR DESCRIPTION
# Summary

When serving a Snapshot, add the canonical url as HTTP header

**Related issues: #XYZ**
https://github.com/pirate/ArchiveBox/issues/92

# Changes these areas

- [ ] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
