### PR TITLE
refactor: Move logging.py to main module to avoid circular import issues

### DIFF
--- a/archivebox/cli/__init__.py
+++ b/archivebox/cli/__init__.py
@@ -110,7 +110,7 @@ def main(args: Optional[List[str]]=NotProvided, stdin: Optional[IO]=NotProvided,
         command.subcommand = 'version'
     
     if command.subcommand not in ('help', 'version', 'status'):
-        from ..cli.logging import log_cli_command
+        from ..logging import log_cli_command
 
         log_cli_command(
             subcommand=command.subcommand,

--- a/archivebox/cli/archivebox_add.py
+++ b/archivebox/cli/archivebox_add.py
@@ -10,7 +10,7 @@ from typing import List, Optional, IO
 
 from ..main import add, docstring
 from ..config import OUTPUT_DIR, ONLY_NEW
-from .logging import SmartFormatter, accept_stdin, stderr
+from ..logging import SmartFormatter, accept_stdin, stderr
 
 
 @docstring(add.__doc__)

--- a/archivebox/cli/archivebox_config.py
+++ b/archivebox/cli/archivebox_config.py
@@ -10,7 +10,7 @@ from typing import Optional, List, IO
 
 from ..main import config, docstring
 from ..config import OUTPUT_DIR
-from .logging import SmartFormatter, accept_stdin
+from ..logging import SmartFormatter, accept_stdin
 
 
 @docstring(config.__doc__)

--- a/archivebox/cli/archivebox_help.py
+++ b/archivebox/cli/archivebox_help.py
@@ -10,7 +10,7 @@ from typing import Optional, List, IO
 
 from ..main import help, docstring
 from ..config import OUTPUT_DIR
-from .logging import SmartFormatter, reject_stdin
+from ..logging import SmartFormatter, reject_stdin
 
 
 @docstring(help.__doc__)

--- a/archivebox/cli/archivebox_init.py
+++ b/archivebox/cli/archivebox_init.py
@@ -10,7 +10,7 @@ from typing import Optional, List, IO
 
 from ..main import init, docstring
 from ..config import OUTPUT_DIR
-from .logging import SmartFormatter, reject_stdin
+from ..logging import SmartFormatter, reject_stdin
 
 
 @docstring(init.__doc__)

--- a/archivebox/cli/archivebox_list.py
+++ b/archivebox/cli/archivebox_list.py
@@ -22,7 +22,7 @@ from ..index import (
     get_corrupted_folders,
     get_unrecognized_folders,
 )
-from .logging import SmartFormatter, accept_stdin
+from ..logging import SmartFormatter, accept_stdin
 
 
 @docstring(list_all.__doc__)

--- a/archivebox/cli/archivebox_remove.py
+++ b/archivebox/cli/archivebox_remove.py
@@ -10,7 +10,7 @@ from typing import Optional, List, IO
 
 from ..main import remove, docstring
 from ..config import OUTPUT_DIR
-from .logging import SmartFormatter, accept_stdin
+from ..logging import SmartFormatter, accept_stdin
 
 
 @docstring(remove.__doc__)

--- a/archivebox/cli/archivebox_schedule.py
+++ b/archivebox/cli/archivebox_schedule.py
@@ -10,7 +10,7 @@ from typing import Optional, List, IO
 
 from ..main import schedule, docstring
 from ..config import OUTPUT_DIR
-from .logging import SmartFormatter, reject_stdin
+from ..logging import SmartFormatter, reject_stdin
 
 
 @docstring(schedule.__doc__)

--- a/archivebox/cli/archivebox_server.py
+++ b/archivebox/cli/archivebox_server.py
@@ -10,7 +10,7 @@ from typing import Optional, List, IO
 
 from ..main import server, docstring
 from ..config import OUTPUT_DIR
-from .logging import SmartFormatter, reject_stdin
+from ..logging import SmartFormatter, reject_stdin
 
 
 @docstring(server.__doc__)

--- a/archivebox/cli/archivebox_shell.py
+++ b/archivebox/cli/archivebox_shell.py
@@ -10,7 +10,7 @@ from typing import Optional, List, IO
 
 from ..main import shell, docstring
 from ..config import OUTPUT_DIR
-from .logging import SmartFormatter, reject_stdin
+from ..logging import SmartFormatter, reject_stdin
 
 
 @docstring(shell.__doc__)

--- a/archivebox/cli/archivebox_status.py
+++ b/archivebox/cli/archivebox_status.py
@@ -10,7 +10,7 @@ from typing import Optional, List, IO
 
 from ..main import status, docstring
 from ..config import OUTPUT_DIR
-from .logging import SmartFormatter, reject_stdin
+from ..logging import SmartFormatter, reject_stdin
 
 
 @docstring(status.__doc__)

--- a/archivebox/cli/archivebox_update.py
+++ b/archivebox/cli/archivebox_update.py
@@ -22,7 +22,7 @@ from ..index import (
     get_corrupted_folders,
     get_unrecognized_folders,
 )
-from .logging import SmartFormatter, accept_stdin
+from ..logging import SmartFormatter, accept_stdin
 
 
 @docstring(update.__doc__)

--- a/archivebox/cli/archivebox_version.py
+++ b/archivebox/cli/archivebox_version.py
@@ -10,7 +10,7 @@ from typing import Optional, List, IO
 
 from ..main import version, docstring
 from ..config import OUTPUT_DIR
-from .logging import SmartFormatter, reject_stdin
+from ..logging import SmartFormatter, reject_stdin
 
 
 @docstring(version.__doc__)

--- a/archivebox/core/admin.py
+++ b/archivebox/core/admin.py
@@ -3,7 +3,7 @@ from django.utils.html import format_html
 
 from util import htmldecode, urldecode
 from core.models import Snapshot
-from cli.logging import printable_filesize
+from archivebox.logging import printable_filesize
 
 # TODO: https://stackoverflow.com/questions/40760880/add-custom-button-to-django-admin-panel
 

--- a/archivebox/core/welcome_message.py
+++ b/archivebox/core/welcome_message.py
@@ -1,4 +1,4 @@
-from cli.logging import log_shell_welcome_msg
+from archivebox.logging import log_shell_welcome_msg
 
 
 if __name__ == '__main__':

--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -12,7 +12,7 @@ from ..index import (
     patch_main_index,
 )
 from ..util import enforce_types
-from ..cli.logging import (
+from ..logging import (
     log_archiving_started,
     log_archiving_paused,
     log_archiving_finished,

--- a/archivebox/extractors/archive_org.py
+++ b/archivebox/extractors/archive_org.py
@@ -19,7 +19,7 @@ from ..config import (
     CURL_VERSION,
     CURL_USER_AGENT,
 )
-from ..cli.logging import TimedProgress
+from ..logging import TimedProgress
 
 
 

--- a/archivebox/extractors/dom.py
+++ b/archivebox/extractors/dom.py
@@ -16,7 +16,7 @@ from ..config import (
     SAVE_DOM,
     CHROME_VERSION,
 )
-from ..cli.logging import TimedProgress
+from ..logging import TimedProgress
 
 
 

--- a/archivebox/extractors/favicon.py
+++ b/archivebox/extractors/favicon.py
@@ -15,7 +15,7 @@ from ..config import (
     CHECK_SSL_VALIDITY,
     CURL_USER_AGENT,
 )
-from ..cli.logging import TimedProgress
+from ..logging import TimedProgress
 
 
 @enforce_types

--- a/archivebox/extractors/git.py
+++ b/archivebox/extractors/git.py
@@ -22,7 +22,7 @@ from ..config import (
     GIT_DOMAINS,
     CHECK_SSL_VALIDITY
 )
-from ..cli.logging import TimedProgress
+from ..logging import TimedProgress
 
 
 

--- a/archivebox/extractors/media.py
+++ b/archivebox/extractors/media.py
@@ -18,7 +18,7 @@ from ..config import (
     YOUTUBEDL_VERSION,
     CHECK_SSL_VALIDITY
 )
-from ..cli.logging import TimedProgress
+from ..logging import TimedProgress
 
 
 @enforce_types

--- a/archivebox/extractors/pdf.py
+++ b/archivebox/extractors/pdf.py
@@ -16,7 +16,7 @@ from ..config import (
     SAVE_PDF,
     CHROME_VERSION,
 )
-from ..cli.logging import TimedProgress
+from ..logging import TimedProgress
 
 
 @enforce_types

--- a/archivebox/extractors/screenshot.py
+++ b/archivebox/extractors/screenshot.py
@@ -16,7 +16,7 @@ from ..config import (
     SAVE_SCREENSHOT,
     CHROME_VERSION,
 )
-from ..cli.logging import TimedProgress
+from ..logging import TimedProgress
 
 
 

--- a/archivebox/extractors/title.py
+++ b/archivebox/extractors/title.py
@@ -18,7 +18,7 @@ from ..config import (
     CURL_VERSION,
     CURL_USER_AGENT,
 )
-from ..cli.logging import TimedProgress
+from ..logging import TimedProgress
 
 
 HTML_TITLE_REGEX = re.compile(

--- a/archivebox/extractors/wget.py
+++ b/archivebox/extractors/wget.py
@@ -31,7 +31,7 @@ from ..config import (
     WGET_USER_AGENT,
     COOKIES_FILE,
 )
-from ..cli.logging import TimedProgress
+from ..logging import TimedProgress
 
 
 @enforce_types

--- a/archivebox/index/__init__.py
+++ b/archivebox/index/__init__.py
@@ -27,7 +27,7 @@ from ..config import (
     ANSI,
     stderr,
 )
-from ..cli.logging import (
+from ..logging import (
     TimedProgress,
     log_indexing_process_started,
     log_indexing_process_finished,

--- a/archivebox/logging.py
+++ b/archivebox/logging.py
@@ -1,4 +1,4 @@
-__package__ = 'archivebox.cli'
+__package__ = 'archivebox'
 
 import re
 import os
@@ -13,11 +13,11 @@ from datetime import datetime
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Union, IO
 
-from ..index.schema import Link, ArchiveResult
-from ..index.json import to_json
-from ..index.csv import links_to_csv
-from ..util import enforce_types
-from ..config import (
+from .index.schema import Link, ArchiveResult
+from .index.json import to_json
+from .index.csv import links_to_csv
+from .util import enforce_types
+from .config import (
     ConfigDict,
     PYTHON_ENCODING,
     ANSI,
@@ -153,7 +153,7 @@ def progress_bar(seconds: int, prefix: str='') -> None:
 
 
 def log_cli_command(subcommand: str, subcommand_args: List[str], stdin: Optional[str], pwd: str):
-    from ..config import VERSION, ANSI
+    from .config import VERSION, ANSI
     cmd = ' '.join(('archivebox', subcommand, *subcommand_args))
     stdin_hint = ' < /dev/stdin' if not stdin.isatty() else ''
     stderr('{black}[i] [{now}] ArchiveBox v{VERSION}: {cmd}{stdin_hint}{reset}'.format(

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -88,7 +88,7 @@ from .config import (
     USER_CONFIG,
     get_real_name,
 )
-from .cli.logging import (
+from .logging import (
     TERM_WIDTH,
     TimedProgress,
     log_importing_started,

--- a/archivebox/parsers/__init__.py
+++ b/archivebox/parsers/__init__.py
@@ -29,7 +29,7 @@ from ..util import (
     URL_REGEX,
 )
 from ..index.schema import Link
-from ..cli.logging import pretty_path, TimedProgress, log_source_saved
+from ..logging import pretty_path, TimedProgress, log_source_saved
 from .pocket_html import parse_pocket_html_export
 from .pinboard_rss import parse_pinboard_rss_export
 from .shaarli_rss import parse_shaarli_rss_export


### PR DESCRIPTION
# Summary

Unittest and other activities are tricky because attempting to import a single function can cause a circular import issue.
This was tracked down to be `cli.logging`'s fault. This changes the location of the logging module, which is used pretty much everywhere, so cli is not imported along with it, causing this issue.

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

# Roadmap Goals

This PR helps us move towards xyz roadmap goal, as outlined here: https://github.com/pirate/ArchiveBox#roadmap
(delete this section if it's just a bugfix / simple PR)
