### PR TITLE
 fix: Remove imports causing circular import issues

### DIFF
--- a/archivebox/logging.py
+++ b/archivebox/logging.py
@@ -410,7 +410,7 @@ def log_removal_finished(all_links: int, to_keep: int):
 
 
 def log_shell_welcome_msg():
-    from . import list_subcommands
+    from .cli import list_subcommands
 
     print('{green}# ArchiveBox Imports{reset}'.format(**ANSI))
     print('{green}from archivebox.core.models import Snapshot, User{reset}'.format(**ANSI))

--- a/archivebox/logging.py
+++ b/archivebox/logging.py
@@ -11,7 +11,10 @@ from multiprocessing import Process
 
 from datetime import datetime
 from dataclasses import dataclass
-from typing import Optional, List, Dict, Union, IO
+from typing import Optional, List, Dict, Union, IO, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .index.schema import Link, ArchiveResult
 
 from .util import enforce_types
 from .config import (
@@ -282,7 +285,7 @@ def log_archiving_finished(num_links: int):
     print('        archivebox server')
 
 
-def log_link_archiving_started(link, link_dir: str, is_new: bool):
+def log_link_archiving_started(link: "Link", link_dir: str, is_new: bool):
     # [*] [2019-03-22 13:46:45] "Log Structured Merge Trees - ben stopford"
     #     http://www.benstopford.com/2015/02/14/log-structured-merge-trees/
     #     > output/archive/1478739709
@@ -300,7 +303,7 @@ def log_link_archiving_started(link, link_dir: str, is_new: bool):
         pretty_path(link_dir),
     ))
 
-def log_link_archiving_finished(link, link_dir: str, is_new: bool, stats: dict):
+def log_link_archiving_finished(link: "Link", link_dir: str, is_new: bool, stats: dict):
     total = sum(stats.values())
 
     if stats['failed'] > 0 :
@@ -315,7 +318,7 @@ def log_archive_method_started(method: str):
     print('      > {}'.format(method))
 
 
-def log_archive_method_finished(result):
+def log_archive_method_finished(result: "ArchiveResult"):
     """quote the argument with whitespace in a command so the user can 
        copy-paste the outputted string directly to run the cmd
     """
@@ -372,7 +375,7 @@ def log_list_finished(links):
     print()
 
 
-def log_removal_started(links, yes: bool, delete: bool):
+def log_removal_started(links: List["Link"], yes: bool, delete: bool):
     print('{lightyellow}[i] Found {} matching URLs to remove.{reset}'.format(len(links), **ANSI))
     if delete:
         file_counts = [link.num_outputs for link in links if os.path.exists(link.link_dir)]
@@ -446,7 +449,7 @@ def printable_filesize(num_bytes: Union[int, float]) -> str:
 
 
 @enforce_types
-def printable_folders(folders,
+def printable_folders(folders: Dict[str, Optional["Link"]],
                       json: bool=False,
                       csv: Optional[str]=None) -> str:
     if json: 


### PR DESCRIPTION
# Summary

The logging module is causing issues because it is importing things outside its scope. Most of the problem is the typing. I removed that for now to make everything work again. We can discuss a better solution later.

**Related issues: https://github.com/pirate/ArchiveBox/issues/372

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

