### PR TITLE
fix: Use w3lib to improve the encoding extraction

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setuptools.setup(
         "ipython",
         "youtube-dl",
         "python-crontab==2.5.1",
-        "w3lib==v1.22.0",
+        "w3lib==1.22.0",
         # "croniter",
         # Some/all of these will likely be added in the future:
         # wpull

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setuptools.setup(
         "ipython",
         "youtube-dl",
         "python-crontab==2.5.1",
+        "w3lib==v1.22.0",
         # "croniter",
         # Some/all of these will likely be added in the future:
         # wpull

--- a/tests/mock_server/server.py
+++ b/tests/mock_server/server.py
@@ -11,7 +11,9 @@ def index():
 @route("/static/<filename>")
 def static_path(filename):
     template_path = abspath(getcwd()) / Path("tests/mock_server/templates")
-    return static_file(filename, root=template_path)
+    response = static_file(filename, root=template_path)
+    response.set_header("Content-Type", "")
+    return response
 
 def start():
     run(host='localhost', port=8080)

--- a/tests/mock_server/templates/shift_jis.html
+++ b/tests/mock_server/templates/shift_jis.html
@@ -1,0 +1,769 @@
+<HTML>
+	<head>
+		<meta http-equiv="content-type" content="text/html; charset=Shift_JIS"/>
+		<META http-equiv='Content-Style-Type' content='text/css'>
+		<meta name="keywords" content="鹿児島,かごしま,ニュース,報道,天気,気象,事件,事故､地域情報,イベント"/>
+		<meta property="og:title" content="鹿児島のニュース｜MBC南日本放送">
+		<meta property="og:description" content="鹿児島のニュース MBC南日本放送">
+		<meta property="og:image" content="http://www.mbc.co.jp/news/img/image.png">
+		<meta property="og:type" content="website"/>
+		<meta property="og:url" contetnt="http://www.mbc.co.jp/news/">
+		<meta property="og:locale" content="ja_JP"/>
+		<title>鹿児島のニュース｜MBC南日本放送</title>
+		<script type="text/javascript" src="../../ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+		<script type="text/javascript" src="js/scrolltopcontrol.js"></script>
+		<script type="text/javascript" src="js/scrollsmoothly.js" charset="utf-8"></script>
+		<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+		<meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0">
+		<meta http-equiv="imagetoolbar" content="no">
+		<SCRIPT language="JavaScript" src="js/toggle.js"></SCRIPT>
+		<link rel="stylesheet" type="text/css" href="mbcnews.css">
+		<link
+		rel="stylesheet" href="../mbc-globalnav/mbc-globalnav.css" charset="utf-8">
+
+		<!-- Global site tag (gtag.js) - Google Analytics -->
+		<script async src="../../www.googletagmanager.com/gtag/js@id=UA-22520034-2"></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+function gtag() {
+dataLayer.push(arguments);
+}
+gtag('js', new Date());
+
+gtag('config', 'UA-22520034-2');
+		</script>
+		<!-- Global site tag (gtag.js) - Google Analytics END -->
+
+
+		<!-- アドセンス -->
+		<script async src="../../securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+		<link rel="stylesheet" href="../css/adsence.css">
+		<script>
+			window.googletag = window.googletag || {
+cmd: []
+};
+googletag.cmd.push(function () {
+googletag.defineSlot('/193632318/LMC/LMC_TV/mbc/PC_all/rectangle1', [
+[
+1, 1
+],
+[
+300, 250
+],
+[
+300, 600
+]
+], 'div-gpt-ad-1570102688339-0').addService(googletag.pubads());
+googletag.defineSlot('/193632318/LMC/LMC_TV/mbc/PC_all/rectangle2', [
+[
+1, 1
+],
+[
+300, 250
+],
+[
+300, 600
+]
+], 'div-gpt-ad-1570102823361-0').addService(googletag.pubads());
+googletag.pubads().enableSingleRequest();
+googletag.enableServices();
+});
+		</script>
+		<script>
+			window.googletag = window.googletag || {
+cmd: []
+};
+googletag.cmd.push(function () {
+googletag.defineSlot('/193632318/LMC/LMC_TV/mbc/SP_all/rectangle1', [
+[
+1, 1
+],
+[
+300, 250
+]
+], 'div-gpt-ad-1570102909947-0').addService(googletag.pubads());
+googletag.pubads().enableSingleRequest();
+googletag.enableServices();
+});
+		</script>
+		<!-- アドセンス END-->
+
+
+	</head>
+	<body>
+		<!--ヘッダー-->
+		<nav id="mbc-globalnav" class="mbc-globalnav" role="navigation"></nav>
+		<script src="../mbc-globalnav/mbc-globalnav.js" charset="utf-8"></script>
+		<!--ヘッダー-->
+
+		<DIV id="mbcnews-header">
+			<h1>MBC NEWS</h1>
+
+			<DIV class="mbcnews-follow">
+				<ul>
+					<li class="follow-t">フォローする</li>
+					<li>
+						<a class="tw-follow-btn" href="https://twitter.com/intent/follow?screen_name=MBC_newsnow" target="_blank" onclick="window.open(this.href, 'window', 'width=600, height=400, menubar=no, toolbar=no, scrollbars=yes'); return false;"><IMG src="../sns/img/twitter.png"></a>
+					</li>
+					<li>
+						<A href="https://www.facebook.com/mbc.newsnow" target="_blank"><IMG src="../sns/img/facebook.png"></A>
+					</li>
+				</ul>
+			</DIV>
+		</DIV>
+		<!-- end #mbcnews-header -->
+
+
+		<DIV id='mbcnews-top'>
+			<h2 id='200722'>07月22日(水)</h2>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043706&amp;ap='><IMG src='img/mbcnews.png'><h3>諏訪之瀬島で爆発　噴煙１２００メートル
+						<span>[23:10]</span>
+					</h3>
+					<p>十島村の諏訪之瀬島で２２日夜、爆発的噴火が発生し、噴煙が火口から１２００メートルの高さまで上がりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043705&amp;ap='><IMG src='../web-news2/2020072200043705.jpg'><h3>二十四節気「大暑」　鹿児島市で３５．５度　初の猛暑日<span>[20:03]</span>
+					</h3>
+					<p>２２日は二十四節気の一つ「大暑」で、１年で最も暑い時期とされます。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043704&amp;ap='><IMG src='../web-news2/2020072200043704.jpg'><h3>「ＧｏＴｏトラベル」キャンペーン開始　戸惑いと不安の声も<span>[20:02]</span>
+					</h3>
+					<p>新型コロナウイルスの影響で打撃を受けている観光業界を支援する国の「ＧｏＴｏトラベル」キャンペーンが２２日から始まりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043701&amp;ap='><IMG src='../web-news2/2020072200043701.jpg'><h3>４連休前に　鹿児島空港で新型コロナ対策強化　出発客の検温も<span>[19:48]</span>
+					</h3>
+					<p>２３日からの４連休、新型コロナウイルスの対策を強化するため、鹿児島空港ではサーモグラフィーが増設され、新たに出発客の体温測定も始まりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043703&amp;ap='><IMG src='../web-news2/2020072200043703.jpg'><h3>新型コロナ新たに２人感染　クラスター落ち着くも対策継続を<span>[19:48]</span>
+					</h3>
+					<p>鹿児島県内では２２日、新型コロナウイルスの感染者が新たに２人確認され、累計は１７４人となりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043700&amp;ap='><IMG src='../web-news2/2020072200043700.jpg'><h3>記録的大雨で被害　鹿児島県伊佐市を江藤農水相が視察<span>[19:47]</span>
+					</h3>
+					<p>今月上旬の記録的大雨で大きな被害を受けた鹿児島県伊佐市を２２日、江藤拓農林水産大臣が訪れ、農業被害の状況などを確認しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043699&amp;ap='><IMG src='../web-news2/2020072200043699.jpg'><h3>高校野球”代替大会” 決勝トーナメントが開幕<span>[19:46]</span>
+					</h3>
+					<p>新型コロナウイルスの影響で中止となった鹿児島県の夏の高校野球の代替大会は、２２日から各地区の代表１６校による決勝トーナメントが始まりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043697&amp;ap='><IMG src='../web-news2/2020072200043697.jpg'><h3>小学校の校庭の木でアオバズクが子育て中　鹿児島県阿久根市<span>[19:44]</span>
+					</h3>
+					<p>鹿児島県阿久根市の小学校の校庭に植えられた木で、アオバズクが子育てをしていて、学校の子どもたちがその様子を見守っています。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043698&amp;ap='><IMG src='../web-news2/2020072200043698.jpg'><h3>新鹿児島県知事・塩田康一氏に聞く　新総合体育館整備と本港区再開発<span>[19:44]</span>
+					</h3>
+					<p>来週２８日に知事に就任する塩田康一さんに、県政の課題を聞くシリーズ。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043696&amp;ap='><IMG src='../web-news2/2020072200043696.jpg'><h3>保育園児も収穫　ブドウのはさみ入れ式　薩摩川内市<span>[19:43]</span>
+					</h3>
+					<p>鹿児島県内有数のブドウの産地、薩摩川内市のブドウ園で２２日、はさみ入れ式が行われました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043695&amp;ap='><IMG src='../web-news2/2020072200043695.jpg'><h3>鹿児島県新型コロナ　新たに２人感染確認
+						<span>[18:10]</span>
+					</h3>
+					<p>鹿児島県は２２日、新型コロナウイルスの感染者を新たに２人確認したと発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043692&amp;ap='><IMG src='../web-news2/2020072200043692.jpg'><h3>飲食店経営者らが新型コロナ対策を学ぶ　鹿児島市<span>[16:14]</span>
+					</h3>
+					<p>鹿児島市で２２日、飲食店などの経営者らが新型コロナ対策を学ぶ、研修会が開かれました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043691&amp;ap='><IMG src='../web-news2/2020072200043691.jpg'><h3>老舗ホテルが営業再開　プール開き　鹿児島県指宿市<span>[16:13]</span>
+					</h3>
+					<p>鹿児島県指宿市の老舗ホテル、指宿白水館で本格的な夏を前に、恒例のプール開きが行われました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043688&amp;ap='><IMG src='../web-news2/2020072200043688.jpg'><h3>鹿児島空港にサーモグラフィー３台設置　連休前に新型コロナ対策強化<span>[12:20]</span>
+					</h3>
+					<p>２３日からの４連休を前に鹿児島空港の国内線には、新型コロナウイルスの感染拡大を防ぐため、検温用の新たなサーモグラフィー３台が設置されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043689&amp;ap='><IMG src='../web-news2/2020072200043689.jpg'><h3>新型コロナで発表会中止　学校の中庭でダンスを披露<span>[12:19]</span>
+					</h3>
+					<p>鹿児島県霧島市の中学校が、新型コロナウイルスの影響でダンス発表の機会を失った生徒に活躍の場を提供しようと、発表会を開きました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072200043686&amp;ap='><IMG src='../web-news2/2020072200043686.jpg'><h3>薩摩、大隅、種子島・屋久地方に高温注意情報　日中３５度以上予想<span>[10:56]</span>
+					</h3>
+					<p>薩摩・大隅地方、種子島・屋久島地方は２２日、日中の気温が３５度以上の猛暑日となるところがある見込みです。</p>
+				</a>
+			</li>
+			<h2 id='200721'>07月21日(火)</h2>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043685&amp;ap='><IMG src='img/mbcnews.png'><h3>奄美市コンビニ強盗未遂事件　男に懲役４年求刑<span>[20:07]</span>
+					</h3>
+					<p>鹿児島県奄美市で去年１月、コンビニエンスストアに包丁を持って押し入り現金を奪おうとしたとして、強盗未遂の罪に問われている男の裁判が鹿児島地裁名瀬支部で開かれ、検察は男に懲役４年を求刑しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043683&amp;ap='><IMG src='../web-news2/2020072100043683.jpg'><h3>新型コロナ　新たに２人感染確認　鹿児島県内１７２人に<span>[19:51]</span>
+					</h3>
+					<p>鹿児島市で新型コロナウイルスの感染者が新たに２人確認され、鹿児島県内の感染者の累計は１７２人となりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043682&amp;ap='><IMG src='../web-news2/2020072100043682.jpg'><h3>新鹿児島県知事・塩田康一氏に聞く　新型コロナ対策<span>[19:49]</span>
+					</h3>
+					<p>今月１２日に行われた鹿児島県知事選挙で初当選した塩田康一さんは、今月２８日に知事に就任します。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043681&amp;ap='><IMG src='../web-news2/2020072100043681.jpg'><h3>一部学校で夏休み開始　一方で授業続く学校も<span>[19:48]</span>
+					</h3>
+					<p>鹿児島県内の一部の学校では２１日から夏休みが始まりましたが、一方で新型コロナウイルスに伴う休校による授業の遅れを取り戻すため、１学期の授業が続いている学校もあります。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043680&amp;ap='><IMG src='../web-news2/2020072100043680.jpg'><h3>ネオワイズ彗星　鹿児島でも撮った！<span>[19:47]</span>
+					</h3>
+					<p>観測条件次第では、肉眼で見ることができるほど明るいと、インターネットなどで話題となっている彗星「ネオワイズ彗星」。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043679&amp;ap='><IMG src='../web-news2/2020072100043679.jpg'><h3>奄美の民謡・シマ唄の第一人者　坪山豊さん死去<span>[19:46]</span>
+					</h3>
+					<p>鹿児島県徳之島の闘牛をモチーフにした「ワイド節」の作曲者で、奄美の民謡・シマ唄の第一人者として活躍した坪山豊さんが２０日、老衰のため亡くなりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043678&amp;ap='><IMG src='../web-news2/2020072100043678.jpg'><h3>ＪＲ鹿児島本線　鹿児島中央～川内　一部区間２７日から再開<span>[19:38]</span>
+					</h3>
+					<p>大雨の影響でＪＲ鹿児島本線の鹿児島中央駅と川内駅の間は、運転見合わせが続いていますが、一部区間が２７日から臨時ダイヤで再開することになりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043677&amp;ap='><IMG src='../web-news2/2020072100043677.jpg'><h3>お中元商戦　新型コロナの影響で変化も　鹿児島市のデパート<span>[19:36]</span>
+					</h3>
+					<p>お中元の季節を迎えていますが、新型コロナウイルスの影響もあり、今年のお中元商戦には変化もあるようです。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043674&amp;ap='><IMG src='../web-news2/2020072100043674.jpg'><h3>種子島南東沖で地震　南種子町で震度１<span>[18:03]</span>
+					</h3>
+					<p>２１日午後５時５４分ごろ、種子島南東沖を震源地とする地震がありました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043673&amp;ap='><IMG src='../web-news2/2020072100043673.jpg'><h3>土用丑の日　ウナギ専門店にぎわう<span>[16:36]</span>
+					</h3>
+					<p>２１日は土用の丑の日、鹿児島市のウナギ専門店は大勢の客でにぎわっています。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043672&amp;ap='><IMG src='../web-news2/2020072100043672.jpg'><h3>中学生が“金峰コシヒカリ”の稲刈り体験　鹿児島県南さつま市<span>[16:35]</span>
+					</h3>
+					<p>超早場米の産地、鹿児島県南さつま市金峰町で、地元の中学生が稲刈りを体験しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043671&amp;ap='><IMG src='../web-news2/2020072100043671.jpg'><h3>姶良市の企業が鹿児島市に医療マスク４万枚を贈る<span>[16:34]</span>
+					</h3>
+					<p>新型コロナウイルスの感染予防対策に役立ててもらおうと、鹿児島県内でタイヤ販売事業を手掛ける姶良市の企業が、鹿児島市にマスク４万枚を贈りました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043670&amp;ap='><IMG src='../web-news2/2020072100043670.jpg'><h3>鹿児島・県道６３号　有明北ＩＣー有明東ＩＣ　通行止め
+						<span>[15:25]</span>
+					</h3>
+					<p>鹿児島県の県道６３号志布志福山線の有明北インターと有明東インターの間が、陥没のため通行止めとなっています。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043669&amp;ap='><IMG src='img/mbcnews.png'><h3>トラクターの下敷きになり男性死亡　鹿児島県日置市<span>[15:06]</span>
+					</h3>
+					<p>鹿児島県日置市で２１日午前、高齢の男性がトラクターの下敷きになり、死亡しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043668&amp;ap='><IMG src='../web-news2/2020072100043668.jpg'><h3>かごしま水族館に５万匹のカタクチイワシが仲間入り<span>[12:00]</span>
+					</h3>
+					<p>２３日からの連休を前に２１日朝、かごしま水族館に５万匹のカタクチイワシが仲間入りし、早速、群れをなして泳ぐ様子が見られました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072100043667&amp;ap='><IMG src='../web-news2/2020072100043667.jpg'><h3>高校生が観光・防災対策を市に提言　鹿児島県霧島市<span>[11:54]</span>
+					</h3>
+					<p>文部科学省のスーパーサイエンスハイスクールに指定されている、鹿児島県霧島市の国分高校が、観光や防災などについての提言を市に行いました。</p>
+				</a>
+			</li>
+			<h2 id='200720'>07月20日(月)</h2>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043666&amp;ap='><IMG src='img/mbcnews.png'><h3>鹿児島市の港で見つかった遺体　４７歳男性と判明<span>[20:26]</span>
+					</h3>
+					<p>鹿児島市の港で１８日に見つかった遺体の身元について、警察は２０日、市内に住む４７歳の土木作業員の男性だったと発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043665&amp;ap='><IMG src='../web-news2/2020072000043665.jpg'><h3>平年より２１日遅く　奄美地方　観測史上最も遅い梅雨明け<span>[19:42]</span>
+					</h3>
+					<p>２０日の奄美地方は、太平洋高気圧に覆われて青空が広がり、鹿児島地方気象台は午前１１時に「奄美地方は梅雨明けしたとみられる」と発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043664&amp;ap='><IMG src='../web-news2/2020072000043664.jpg'><h3>奄美・龍郷町の小中学校で終業式　鹿児島県内の一部学校が夏休みへ<span>[19:41]</span>
+					</h3>
+					<p>新型コロナウイルスの影響で休校措置が取られた鹿児島県内の公立小・中学校の多くでは、夏休みを短縮する方針ですが、予定通り２１日から夏休みに入る離島など一部の学校では、２０日、１学期の終業式が行われました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043663&amp;ap='><IMG src='../web-news2/2020072000043663.jpg'><h3>海水浴場で一時４人が溺れる　全員救助　鹿児島県阿久根市<span>[19:40]</span>
+					</h3>
+					<p>鹿児島県阿久根市の海水浴場で２０日午後、女性４人が溺れ、救助されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043662&amp;ap='><IMG src='../web-news2/2020072000043662.jpg'><h3>「ディスカバー鹿児島」の自粛要請を延長　８月４日まで<span>[19:39]</span>
+					</h3>
+					<p>鹿児島県は新型コロナの感染者数増加を受け、利用者に自粛を要請している宿泊施設支援キャンペーン「ディスカバー鹿児島」の自粛要請期間を、来月４日まで延長することを発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043661&amp;ap='><IMG src='../web-news2/2020072000043661.jpg'><h3>「安心安全の天文館に」飲食店およそ５０店舗が一斉消毒　鹿児島市<span>[19:38]</span>
+					</h3>
+					<p>接待を伴う飲食店を対象に、鹿児島県から出されていた休業要請の期間が、明日までとなりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043660&amp;ap='><IMG src='../web-news2/2020072000043660.jpg'><h3>独自のＰＣＲ検査機器の試験運用開始　鹿児島県霧島市<span>[19:37]</span>
+					</h3>
+					<p>鹿児島県霧島市は、新型コロナウイルスへの感染の有無を調べるＰＣＲ検査機器の運用を、独自に２０日から始めました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043659&amp;ap='><IMG src='../web-news2/2020072000043659.jpg'><h3>新型コロナ　国の基準「退院前にＰＣＲ検査せず」　根拠は？<span>[19:36]</span>
+					</h3>
+					<p>鹿児島市のショーパブで、国内最大級のクラスターが発生し、県内では今月に入り、医療機関への入院やホテルで療養する人が増加しています。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043658&amp;ap='><IMG src='../web-news2/2020072000043658.jpg'><h3>ＵＡＥの火星探査機搭載　Ｈ２Aロケット打ち上げ成功<span>[19:35]</span>
+					</h3>
+					<p>ＵＡＥ＝アラブ首長国連邦の火星探査機を搭載したＨ２Ａロケットが、鹿児島県の種子島宇宙センターから打ち上げられ、打ち上げは成功しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043657&amp;ap='><IMG src='../web-news2/2020072000043657.jpg'><h3>新庁舎移転問題　住民投票を８月９日に実施　鹿児島県垂水市<span>[19:34]</span>
+					</h3>
+					<p>鹿児島県垂水市の新しい庁舎の移転新築計画の是非を問う住民投票が、来月９日に行われることになりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043656&amp;ap='><IMG src='../web-news2/2020072000043656.jpg'><h3>コロナに負けない！コロナ禍で新しい形の運動会<span>[19:34]</span>
+					</h3>
+					<p>新型コロナウイルスの感染拡大で先が見えない不安の中、逆境に立ち向かう人や企業を紹介するシリーズ「鹿児島発コロナに負けない！」今回は、コロナ禍での新しい形での運動会について取材しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043655&amp;ap='><IMG src='../web-news2/2020072000043655.jpg'><h3>２１日は「土用丑の日」　ウナギのかば焼き出荷ピーク　鹿児島県大崎町<span>[19:32]</span>
+					</h3>
+					<p>２１日の「土用の丑の日」を前に、鹿児島県大崎町では、ウナギのかば焼きなどの出荷がピークを迎えています。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043654&amp;ap='><IMG src='../web-news2/2020072000043654.jpg'><h3>新型コロナ　鹿児島市で新たに５人の感染確認　県内１７０人に<span>[17:29]</span>
+					</h3>
+					<p>鹿児島県内では２０日、新たに新型コロナウイルスへの感染者が５人確認されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043653&amp;ap='><IMG src='../web-news2/2020072000043653.jpg'><h3>鹿児島・川内原発１号機　制御棒曲がった原因は挿入時の接触か<span>[17:11]</span>
+					</h3>
+					<p>定期検査中の鹿児島県の川内原発１号機では、今月１６日に原子炉の核分裂を制御する制御棒のうちの１本が曲がっているのが見つかりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043647&amp;ap='><IMG src='../web-news2/2020072000043647.jpg'><h3>奄美地方　観測史上最も遅い梅雨明け<span>[11:02]</span>
+					</h3>
+					<p>鹿児島地方気象台は、午前１１時に「奄美地方は梅雨明けしたとみられる」と発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043646&amp;ap='><IMG src='../web-news2/2020072000043646.jpg'><h3>Ｈ２Ａロケット打ち上げ成功　ＵＡＥの火星探査機搭載<span>[07:57]</span>
+					</h3>
+					<p>ＵＡＥ＝アラブ首長国連邦の火星探査機を搭載したＨ２Ａロケットが２０日朝種子島宇宙センターから打ち上げられ、打ち上げは成功しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020072000043645&amp;ap='><IMG src='../web-news2/2020072000043645.jpg'><h3>Ｈ２Ａロケット打ち上げ　ＵＡＥの火星探査機搭載<span>[07:18]</span>
+					</h3>
+					<p>ＵＡＥ＝アラブ首長国連邦の火星探査機を搭載したＨ２Ａロケットが、先ほど午前７時前に種子島宇宙センターから打ち上げられました。</p>
+				</a>
+			</li>
+			<h2 id='200719'>07月19日(日)</h2>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071900043644&amp;ap='><IMG src='../web-news2/2020071900043644.jpg'><h3>Ｈ２Ａロケット４２号機　２０日朝打ち上げ<span>[18:15]</span>
+					</h3>
+					<p>天候不良のため打ち上げが延期されていたＨ２Ａロケット４２号機は、２０日朝、種子島宇宙センターから打ち上げられます。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071900043643&amp;ap='><IMG src='../web-news2/2020071900043643.jpg'><h3>「ＧｏＴｏトラベル」巡り　三反園知事「まずは近隣地域で」<span>[18:13]</span>
+					</h3>
+					<p>鹿児島県の三反園知事は、１９日に行われた全国知事会のウェブ会議で、政府が観光支援で始める「ＧｏＴｏトラベル」について、「新型コロナウイルス感染拡大防止のため、近隣地域から始めるべき」との考えを示しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071900043642&amp;ap='><IMG src='../web-news2/2020071900043642.jpg'><h3>新型コロナ　鹿児島県内新たに１人の感染確認<span>[17:41]</span>
+					</h3>
+					<p>鹿児島市は先ほど、新型コロナウイルスの感染者が新たに１人確認されたと発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071900043641&amp;ap='><IMG src='img/mbcnews.png'><h3>漁港で男性が転落　意識不明　鹿児島・南さつま市<span>[17:30]</span>
+					</h3>
+					<p>鹿児島県南さつま市の漁港沖で１９日午前、船で作業中の男性が海に転落し、意識不明の重体となっています。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071900043640&amp;ap='><IMG src='../web-news2/2020071900043640.jpg'><h3>東京五輪代表・岡澤セオン選手　被災地支援　手作りカレー提供<span>[11:47]</span>
+					</h3>
+					<p>鹿児島県鹿屋市在住で、ボクシング・ウエルター級で東京オリンピックの日本代表の岡澤セオン選手がプロデュースしたカレーが、鹿屋市のホテルで提供されました。</p>
+				</a>
+			</li>
+			<h2 id='200718'>07月18日(土)</h2>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071800043639&amp;ap='><IMG src='img/mbcnews.png'><h3>鹿児島市の港で男性の遺体<span>[21:23]</span>
+					</h3>
+					<p>鹿児島市の港で１８日午後、男性が遺体で見つかりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071800043638&amp;ap='><IMG src='../web-news2/2020071800043638.jpg'><h3>鹿児島・新型コロナ感染発表　１８日は２人　累計１６４人<span>[19:16]</span>
+					</h3>
+					<p>鹿児島県と鹿児島市は新型コロナウイルスの感染者が新たに２人確認されたと１８日、発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071800043636&amp;ap='><IMG src='../web-news2/2020071800043636.jpg'><h3>かごしま暮らし　オンライン移住相談会<span>[17:29]</span>
+					</h3>
+					<p>鹿児島への移住を考える人を対象にしたオンラインでの移住相談会が１８日、開かれました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071800043637&amp;ap='><IMG src='../web-news2/2020071800043637.jpg'><h3>新型コロナ　鹿児島市で新たに１人　県内累計１６４人に<span>[17:10]</span>
+					</h3>
+					<p>鹿児島市は先ほど午後５時に新型コロナウイルスの感染者が、１８日は新たに１人確認されたと発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071800043635&amp;ap='><IMG src='../web-news2/2020071800043635.jpg'><h3>高校野球”代替大会”　地区代表１６校出そろう<span>[16:02]</span>
+					</h3>
+					<p>新型コロナウイルスの影響で中止となった、夏の高校野球の代替大会。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071800043634&amp;ap='><IMG src='../web-news2/2020071800043634.jpg'><h3>新型コロナ　鹿児島県内で初めて警察官の感染確認<span>[12:14]</span>
+					</h3>
+					<p>県警は交通機動隊に所属する２０代の男性警察官が新型コロナウイルスに感染していたことが確認されたと発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071800043633&amp;ap='><IMG src='../web-news2/2020071800043633.jpg'><h3>釣りの男性が海に転落し死亡　鹿児島県霧島市<span>[12:12]</span>
+					</h3>
+					<p>鹿児島県霧島市で１７日夜、釣りをしていた男性が海に転落して死亡しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071800043632&amp;ap='><IMG src='img/mbcnews.png'><h3>鹿児島県警　男性警察官が新型コロナ感染<span>[02:16]</span>
+					</h3>
+					<p>鹿児島県警は１７日、交通機動隊の２０代の男性警察官が新型コロナウイルスに感染したと発表しました。</p>
+				</a>
+			</li>
+			<h2 id='200717'>07月17日(金)</h2>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043629&amp;ap='><IMG src='../web-news2/2020071700043629.jpg'><h3>鹿児島県本土　久々の青空<span>[19:48]</span>
+					</h3>
+					<p>１７日の鹿児島県本土は、前線北側の乾いた空気が流れ込み、青空が広がりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043630&amp;ap='><IMG src='../web-news2/2020071700043630.jpg'><h3>新型コロナ　鹿児島県内の感染確認なし　６月３０日以来１７日ぶり<span>[19:47]</span>
+					</h3>
+					<p>鹿児島県内では１７日、新たな新型コロナウイルスへの感染者は確認されませんでした。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043628&amp;ap='><IMG src='../web-news2/2020071700043628.jpg'><h3>“東京除外”で２２日から「Ｇｏ　Ｔｏ　トラベル」　期待と不安の声<span>[19:45]</span>
+					</h3>
+					<p>新型コロナウイルスで打撃を受けている観光業を支援する「ＧｏＴｏトラベル」キャンペーンについて、政府は来週２２日から東京を除外する形でスタートする方針を示しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043627&amp;ap='><IMG src='../web-news2/2020071700043627.jpg'><h3>１９棟全半焼　放火の罪　消防団員の男に懲役１２年の実刑判決<span>[19:44]</span>
+					</h3>
+					<p>鹿児島県奄美大島の龍郷町でおととし、空き家に火をつけ、住宅など１９棟を全半焼させるなどした現住建造物等放火などの罪に問われている消防団員の裁判員裁判で、懲役１２年の実刑判決が言い渡されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043625&amp;ap='><IMG src='../web-news2/2020071700043625.jpg'><h3>決勝トーナメント目指して！　鹿児島県夏季高校野球大会<span>[19:43]</span>
+					</h3>
+					<p>新型コロナウイルスの影響で中止となった、夏の高校野球の代替大会は、地区予選の終盤を迎えています。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043624&amp;ap='><IMG src='../web-news2/2020071700043624.jpg'><h3>発生３時間後に避難情報　薩摩川内市の河川氾濫で見えた課題<span>[19:42]</span>
+					</h3>
+					<p>薩摩川内市では、今月３日に川内川の支流で氾濫が発生し浸水被害も出ましたが、避難情報が出たのは氾濫発生の３時間後でした。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043622&amp;ap='><IMG src='../web-news2/2020071700043622.jpg'><h3>保育園で「ウナギ給食」　鹿児島県大崎町<span>[19:42]</span>
+					</h3>
+					<p>鹿児島県大崎町の大丸保育園で１７日、給食に出されたのはウナギのかば焼き。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043621&amp;ap='><IMG src='../web-news2/2020071700043621.jpg'><h3>ふるさと特派員が撮った！「白いスズメ」と「金色のドジョウ」<span>[19:40]</span>
+					</h3>
+					<p>ＭＢＣふるさと特派員から、変わった色の生き物の映像が届きました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043631&amp;ap='><IMG src='img/mbcnews.png'><h3>延期のＨ２Ａロケット　今月２０日午前打ち上げへ<span>[19:39]</span>
+					</h3>
+					<p>天候不良で打ち上げが延期されていたＨ２Ａロケット４２号機について、三菱重工は、今月２０日の午前６時５８分に鹿児島県の種子島宇宙センターから打ち上げると発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043620&amp;ap='><IMG src='../web-news2/2020071700043620.jpg'><h3>鹿児島県内　新型コロナ新規感染者はゼロ<span>[17:51]</span>
+					</h3>
+					<p>鹿児島県と鹿児島市は１７日、新しく確認された新型コロナウイルスの感染者はいなかったと発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043617&amp;ap='><IMG src='../web-news2/2020071700043617.jpg'><h3>ＪＲ鹿児島本線　川内－隈之城間で運転再開<span>[16:29]</span>
+					</h3>
+					<p>大雨の影響で運転を見合わせていたＪＲ鹿児島本線の川内ー隈之城の間は、今月２０日から一部で運転を再開します。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043616&amp;ap='><IMG src='../web-news2/2020071700043616.jpg'><h3>屋久島町出張旅費問題　前議長を詐欺の疑いで刑事告発へ<span>[16:06]</span>
+					</h3>
+					<p>鹿児島県屋久島町の前の町議会議長の男性が、出張旅費を不正に受け取っていたとして、住民らが詐欺の疑いで近く刑事告発する考えを示しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043615&amp;ap='><IMG src='../web-news2/2020071700043615.jpg'><h3>薩摩川内市の文化ホール跡地利用　九電提案の施設建設案を採用<span>[16:05]</span>
+					</h3>
+					<p>来年春に閉館する鹿児島県薩摩川内市の川内文化ホールの跡地について、市は九州電力が提案した新たな施設の建設案を採用し、今後協議を進める方針です。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043612&amp;ap='><IMG src='../web-news2/2020071700043612.jpg'><h3>「ＳＤＧｓ」の一環で小型電気自動車を導入　鹿児島相互信用金庫<span>[16:00]</span>
+					</h3>
+					<p>鹿児島相互信用金庫がＳＤＧｓ＝「持続可能な社会を作る活動」の一環として、一人乗りの小型電気自動車を導入し１７日、出発式が行われました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043613&amp;ap='><IMG src='../web-news2/2020071700043613.jpg'><h3>熊本で震度３の地震　鹿児島県長島町で震度１<span>[15:07]</span>
+					</h3>
+					<p>１７日午後２時５４分ごろ熊本県熊本地方を震源地とする地震があり、熊本県で最大震度３を観測しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043611&amp;ap='><IMG src='../web-news2/2020071700043611.jpg'><h3>定期検査中の鹿児島・川内原発１号機で曲がった制御棒確認<span>[11:56]</span>
+					</h3>
+					<p>定期検査中の鹿児島県の川内原発１号機で、制御棒のうちの１本が曲がっているのが確認されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043610&amp;ap='><IMG src='../web-news2/2020071700043610.jpg'><h3>志布志市の県道５１３号　通行止め解除<span>[10:18]</span>
+					</h3>
+					<p>県道５１３号宮ケ原大崎線の鹿児島県志布志市有明町山重付近では、今月６日から土砂崩れのため通行止めとなっていましたが、復旧作業が終わり、１７日午前９時に解除されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071700043609&amp;ap='><IMG src='../web-news2/2020071700043609.jpg'><h3>奄美地方で１７日落雷や突風に注意<span>[09:08]</span>
+					</h3>
+					<p>奄美地方では１７日、落雷や竜巻などの激しい突風、急な強い雨に注意してください。</p>
+				</a>
+			</li>
+			<h2 id='200716'>07月16日(木)</h2>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043608&amp;ap='><IMG src='img/mbcnews.png'><h3>鹿児島県南さつま市で発見の遺体　行方不明の新聞配達員の男性と確認<span>[22:15]</span>
+					</h3>
+					<p>鹿児島県南さつま市の万之瀬川の河川敷で１４日に見つかった男性の遺体は、今月６日から行方が分からなくなっていた南さつま市の新聞配達員の男性と確認されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043607&amp;ap='><IMG src='img/mbcnews.png'><h3>鹿児島市で警察官など名乗る不審電話相次ぐ　注意を<span>[19:48]</span>
+					</h3>
+					<p>鹿児島市では１４日、警察官などを名乗る不審な電話が相次ぎました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043604&amp;ap='><IMG src='../web-news2/2020071600043604.jpg'><h3>寝たきりの母親を殴って死なせた疑い　７０歳長男を逮捕　鹿児島県知名町<span>[19:23]</span>
+					</h3>
+					<p>鹿児島県沖永良部島の知名町で、寝たきりの母親を殴って死亡させたとして、同居する７０歳の長男が傷害致死の疑いで逮捕されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043602&amp;ap='><IMG src='../web-news2/2020071600043602.jpg'><h3>長雨で日照不足　平年の１割未満も　鹿児島県内の消費に影響<span>[19:22]</span>
+					</h3>
+					<p>梅雨の長雨の影響で、鹿児島県の日置市や薩摩川内市では、この１０日間の日照時間が平年の１割にも満たないなど、日照不足が続いています。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043603&amp;ap='><IMG src='../web-news2/2020071600043603.jpg'><h3>記録的大雨の鹿児島県内　各地で復旧作業続く<span>[19:22]</span>
+					</h3>
+					<p>鹿児島県の大隅地方では、今月６日に観測史上最大の時間雨量１０９・５ミリを観測するなど、記録的な大雨となりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043606&amp;ap='><IMG src='../web-news2/2020071600043606.jpg'><h3>新型コロナ新たに４人感染確認　鹿児島県内の感染者は１６２人に<span>[19:21]</span>
+					</h3>
+					<p>鹿児島県内では、４人の新型コロナウイルスへの感染が新たに確認されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043601&amp;ap='><IMG src='../web-news2/2020071600043601.jpg'><h3>新型コロナ宿泊療養施設に　鹿児島県が新たにホテルを借り上げ<span>[19:20]</span>
+					</h3>
+					<p>新型コロナの感染確認が増加する中、鹿児島県は軽症や無症状の感染者などに滞在してもらうために、新たに鹿児島市内のホテル１棟を借り上げたと発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043599&amp;ap='><IMG src='../web-news2/2020071600043599.jpg'><h3>自民党鹿児島県議団　知事選総括の会議　「結論持ち越し」<span>[19:19]</span>
+					</h3>
+					<p>１２日に投票が行われた鹿児島県知事選挙で、推薦した現職候補が敗れたことを受けて、自民党県議団は１６日、総括する会議を開きましたが、結論は持ち越されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043593&amp;ap='><IMG src='../web-news2/2020071600043593.jpg'><h3>鹿児島県議会議員補欠選挙　当選の鶴薗真佐彦さんが初登庁<span>[16:21]</span>
+					</h3>
+					<p>今月１２日に投開票が行われた鹿児島県議会議員薩摩川内市区の補欠選挙で当選した鶴薗真佐彦さんが１６日、初登庁しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043596&amp;ap='><IMG src='../web-news2/2020071600043596.jpg'><h3>「鹿児島市の戦災と復興写真展」始まる　長崎の原爆被害のパネルも<span>[16:21]</span>
+					</h3>
+					<p>鹿児島市役所で、鹿児島と長崎の戦争被害と復興の歩みを収めた写真展が１６日から始まりました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043595&amp;ap='><IMG src='../web-news2/2020071600043595.jpg'><h3>阿久根市の魅力が詰まった「お宿　みどこい」オープン<span>[16:20]</span>
+					</h3>
+					<p>鹿児島県阿久根市の魅力が詰まった宿泊施設「お宿　みどこい」がオープンしました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043591&amp;ap='><IMG src='../web-news2/2020071600043591.jpg'><h3>屋久島町・荒木耕治町長を詐欺などの疑いで書類送検　旅費着服問題<span>[16:00]</span>
+					</h3>
+					<p>屋久島町の荒木耕治町長が出張旅費の一部を着服していた問題を巡り、鹿児島県警は１６日、荒木耕治町長を詐欺などの疑いで書類送検しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043592&amp;ap='><IMG src='../web-news2/2020071600043592.jpg'><h3>鹿児島県内の新型コロナ感染者拡大を受け　仙巌園が休業期間を延長<span>[11:56]</span>
+					</h3>
+					<p>新型コロナウイルスの影響で今年４月から休業している鹿児島市の「仙巌園」は、１７日から営業を再開する予定でしたが、今月に入り、県内で感染者が増えていることを受け、休業期間を延長すると発表しました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043590&amp;ap='><IMG src='../web-news2/2020071600043590.jpg'><h3>鹿屋市の国道２２０号古江バイパス　通行再開<span>[09:16]</span>
+					</h3>
+					<p>国道２２０号古江バイパスの鹿屋市の根木原交差点と垂水市のまさかり交差点の間では、今月６日から土砂の流失の復旧作業のため通行止めとなっていましたが、１６日午前６時に、規制は解除されました。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043589&amp;ap='><IMG src='../web-news2/2020071600043589.jpg'><h3>奄美地方で１７日にかけて落雷や突風に注意<span>[08:30]</span>
+					</h3>
+					<p>奄美地方で１７日にかけて落雷や竜巻などの激し突風、急な強い雨に注意してください。</p>
+				</a>
+			</li>
+			<li>
+				<a href='https://www.mbc.co.jp/news/mbc_news.php?ibocd=2020071600043588&amp;ap='><IMG src='../web-news2/2020071600043588.jpg'><h3>諏訪之瀬島で爆発的噴火<span>[08:17]</span>
+					</h3>
+					<p>十島村の諏訪之瀬島で１６日朝、爆発的噴火が発生しました。</p>
+				</a>
+			</li>
+
+
+		</DIV>
+		<!-- end #mbcnews-top-->
+
+		<!--adsense start-->
+		<br clear="all">
+		<section class="ad_list">
+			<div class="ad2para">
+				<div class="adcenter">
+					<div
+						class="adLeft">
+						<!-- /193632318/LMC/LMC_TV/mbc/PC_all/rectangle1 -->
+						<div id='div-gpt-ad-1570102688339-0'>
+							<script>
+								googletag.cmd.push(function () {
+googletag.display('div-gpt-ad-1570102688339-0');
+});
+							</script>
+						</div>
+					</div>
+
+					<div class="adRight">
+						<div
+							id="pc-banner">
+							<!-- /193632318/LMC/LMC_TV/mbc/PC_all/rectangle2 -->
+							<div id='div-gpt-ad-1570102823361-0'>
+								<script>
+									googletag.cmd.push(function () {
+googletag.display('div-gpt-ad-1570102823361-0');
+});
+								</script>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+
+
+		<section class="ad_list_mobile">
+			<div class="ad2para">
+				<div
+					class="adcenter">
+					<!-- /193632318/LMC/LMC_TV/mbc/SP_all/rectangle1 -->
+					<div id='div-gpt-ad-1570102909947-0'>
+						<script>
+							googletag.cmd.push(function () {
+googletag.display('div-gpt-ad-1570102909947-0');
+});
+						</script>
+					</div>
+				</div>
+			</div>
+		</section>
+		<!--adsense end-->
+
+
+		<!--フッター-->
+		<DIV id="cr">Copyright(c) Minaminihon Broadcasting Co.,Ltd. All rights reserved.<BR>
+			掲載された全ての記事・画像等の無断転載、二次利用をお断りいたします。</DIV>
+		<!--フッター-->
+
+
+	</body>
+</html>

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -3,3 +3,8 @@ from archivebox import util
 def test_download_url_downloads_content():
     text = util.download_url("http://127.0.0.1:8080/static/example.com.html")
     assert "Example Domain" in text
+
+def test_download_url_gets_encoding_from_body():
+    text = util.download_url("http://127.0.0.1:8080/static/shift_jis.html")
+    assert "鹿児島のニュース｜MBC南日本放送" in text
+    assert "掲載された全ての記事・画像等の無断転載、二次利用をお断りいたします" in text


### PR DESCRIPTION
# Summary

Detecting the right encoding is an issue not only for rss feeds (which had a previous fix) but in general. In this PR I generalize that fix, so the flow is:
- Headers
- Body
- Guess it (requests default behavior)

![image](https://user-images.githubusercontent.com/5531776/88195624-dba2be00-cc05-11ea-86f3-f1b6ea4fc18f.png)

Problematic links are all having the right title now.

**Related issues: #257

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk


