### PR TITLE
refactor: Remove old bin/archivebox

### DIFF
--- a/bin/archivebox
+++ b/bin/archivebox
@@ -1,1 +1,0 @@
-../archivebox/__main__.py


### PR DESCRIPTION
# Summary

Remove old `bin/archivebox` symlink. The current entrypoint is the preferred way to use archivebox (directly calling `archivebox` after installing it with python).

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [X] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

