### PR TITLE
feat: Fallback to link detail when there is an issue loading a link

### DIFF
--- a/archivebox/index/json.py
+++ b/archivebox/index/json.py
@@ -53,7 +53,7 @@ def parse_json_main_index(out_dir: str=OUTPUT_DIR) -> Iterator[Link]:
                 try:
                     yield Link.from_json(link_json)
                 except KeyError:
-                    detail_index_path = Path(f"{OUTPUT_DIR}/{ARCHIVE_DIR_NAME}/{link_json['timestamp']}")
+                    detail_index_path = Path(OUTPUT_DIR) / ARCHIVE_DIR_NAME / link_json['timestamp']
                     yield parse_json_link_details(str(detail_index_path))
 
     return ()
@@ -153,6 +153,5 @@ class ExtendedEncoder(pyjson.JSONEncoder):
 @enforce_types
 def to_json(obj: Any, indent: Optional[int]=4, sort_keys: bool=True, cls=ExtendedEncoder) -> str:
     return pyjson.dumps(obj, indent=indent, sort_keys=sort_keys, cls=ExtendedEncoder)
-
 
 

--- a/archivebox/index/json.py
+++ b/archivebox/index/json.py
@@ -53,7 +53,7 @@ def parse_json_main_index(out_dir: str=OUTPUT_DIR) -> Iterator[Link]:
                 try:
                     yield Link.from_json(link_json)
                 except KeyError:
-                    detail_index_path = OUTPUT_DIR / Path(f"archive/{link_json['timestamp']}")
+                    detail_index_path = Path(f"{OUTPUT_DIR}/{ARCHIVE_DIR_NAME}/{link_json['timestamp']}")
                     yield parse_json_link_details(str(detail_index_path))
 
     return ()

--- a/archivebox/index/json.py
+++ b/archivebox/index/json.py
@@ -3,6 +3,7 @@ __package__ = 'archivebox.index'
 import os
 import sys
 import json as pyjson
+from pathlib import Path
 
 from datetime import datetime
 from typing import List, Optional, Iterator, Any
@@ -49,7 +50,11 @@ def parse_json_main_index(out_dir: str=OUTPUT_DIR) -> Iterator[Link]:
         with open(index_path, 'r', encoding='utf-8') as f:
             links = pyjson.load(f)['links']
             for link_json in links:
-                yield Link.from_json(link_json)
+                try:
+                    yield Link.from_json(link_json)
+                except KeyError:
+                    detail_index_path = OUTPUT_DIR / Path(f"archive/{link_json['timestamp']}")
+                    yield parse_json_link_details(str(detail_index_path))
 
     return ()
 


### PR DESCRIPTION

# Summary

When main index lacks some information, fallback to the archive folder for details

**Related issues: #374 
# Changes these areas

- [ ] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

# Roadmap Goals

This PR helps us move towards xyz roadmap goal, as outlined here: https://github.com/pirate/ArchiveBox#roadmap
(delete this section if it's just a bugfix / simple PR)
