### PR TITLE
ensure correct permissions for output folder

### DIFF
--- a/archivebox/config/__init__.py
+++ b/archivebox/config/__init__.py
@@ -864,3 +864,5 @@ def setup_django(out_dir: str=None, check_db=False, config: ConfigDict=CONFIG) -
                 f'No database file {SQL_INDEX_FILENAME} found in OUTPUT_DIR: {config["OUTPUT_DIR"]}')
     except KeyboardInterrupt:
         raise SystemExit(2)
+
+os.umask(0o777 - int(OUTPUT_PERMISSIONS, base=8))

--- a/archivebox/index/__init__.py
+++ b/archivebox/index/__init__.py
@@ -26,6 +26,7 @@ from ..config import (
     URL_BLACKLIST_PTN,
     ANSI,
     stderr,
+    OUTPUT_PERMISSIONS
 )
 from ..logging_util import (
     TimedProgress,
@@ -232,6 +233,8 @@ def write_main_index(links: List[Link], out_dir: str=OUTPUT_DIR, finished: bool=
 
     with timed_index_update(os.path.join(out_dir, SQL_INDEX_FILENAME)):
         write_sql_main_index(links, out_dir=out_dir)
+        os.chmod(os.path.join(out_dir, SQL_INDEX_FILENAME), int(OUTPUT_PERMISSIONS, base=8)) # set here because we don't write it with atomic writes
+
 
     with timed_index_update(os.path.join(out_dir, JSON_INDEX_FILENAME)):
         write_json_main_index(links, out_dir=out_dir)

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -87,7 +87,6 @@ from .config import (
     CONFIG,
     USER_CONFIG,
     get_real_name,
-    OUTPUT_PERMISSIONS
 )
 from .logging_util import (
     TERM_WIDTH,
@@ -241,7 +240,6 @@ def run(subcommand: str,
 @enforce_types
 def init(force: bool=False, out_dir: str=OUTPUT_DIR) -> None:
     """Initialize a new ArchiveBox collection in the current directory"""
-    os.umask(0o777 - int(OUTPUT_PERMISSIONS, base=8))
     os.makedirs(out_dir, exist_ok=True)
     is_empty = not len(set(os.listdir(out_dir)) - ALLOWED_IN_OUTPUT_DIR)
     existing_index = os.path.exists(os.path.join(out_dir, JSON_INDEX_FILENAME))

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -87,6 +87,7 @@ from .config import (
     CONFIG,
     USER_CONFIG,
     get_real_name,
+    OUTPUT_PERMISSIONS
 )
 from .logging_util import (
     TERM_WIDTH,
@@ -240,8 +241,8 @@ def run(subcommand: str,
 @enforce_types
 def init(force: bool=False, out_dir: str=OUTPUT_DIR) -> None:
     """Initialize a new ArchiveBox collection in the current directory"""
+    os.umask(0o777 - int(OUTPUT_PERMISSIONS, base=8))
     os.makedirs(out_dir, exist_ok=True)
-
     is_empty = not len(set(os.listdir(out_dir)) - ALLOWED_IN_OUTPUT_DIR)
     existing_index = os.path.exists(os.path.join(out_dir, JSON_INDEX_FILENAME))
 

--- a/archivebox/system.py
+++ b/archivebox/system.py
@@ -43,7 +43,7 @@ def atomic_write(path: Union[Path, str], contents: Union[dict, str, bytes], over
             dump(contents, f, indent=4, sort_keys=True, cls=ExtendedEncoder)
         elif isinstance(contents, (bytes, str)):
             f.write(contents)
-
+    os.chmod(path, int(OUTPUT_PERMISSIONS, base=8))
 
 @enforce_types
 def chmod_file(path: str, cwd: str='.', permissions: str=OUTPUT_PERMISSIONS) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,8 @@ import subprocess
 from pathlib import Path
 import json
 
+from archivebox.config import OUTPUT_PERMISSIONS
+
 from .fixtures import *
 
 def test_init(tmp_path, process):
@@ -42,4 +44,10 @@ def test_add_link_support_stdin(tmp_path, process):
     with open(archived_item_path / "index.json", "r") as f:
         output_json = json.load(f)
     assert "Example Domain" == output_json['history']['title'][0]['output']
+
+def test_correct_permissions_output_folder(tmp_path, process):
+    index_files = ['index.json', 'index.html', 'index.sqlite3', 'archive']
+    for file in index_files:
+        file_path = tmp_path / file
+        assert oct(file_path.stat().st_mode)[-3:] == OUTPUT_PERMISSIONS
 


### PR DESCRIPTION
# Summary

This PR ensures correct permissions for index files + powerful (& simple) test with @cdvv7788 

**Related issues: #377 

# Changes these areas
- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
