### PR TITLE
fix: Remove link from sql index on remove command

### DIFF
--- a/archivebox/index/sql.py
+++ b/archivebox/index/sql.py
@@ -21,6 +21,16 @@ def parse_sql_main_index(out_dir: str=OUTPUT_DIR) -> Iterator[Link]:
     )
 
 @enforce_types
+def remove_from_sql_main_index(links: List[Link], out_dir: str=OUTPUT_DIR) -> None:
+    setup_django(out_dir, check_db=True)
+    from core.models import Snapshot
+    from django.db import transaction
+
+    with transaction.atomic():
+        for link in links:
+            Snapshot.objects.filter(url=link.url).delete()
+
+@enforce_types
 def write_sql_main_index(links: List[Link], out_dir: str=OUTPUT_DIR) -> None:
     setup_django(out_dir, check_db=True)
     from core.models import Snapshot

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1,0 +1,8 @@
+from .fixtures import *
+
+def test_remove_leaves_index_in_consistent_state(tmp_path, process):
+    os.chdir(tmp_path)
+    subprocess.run(['archivebox', 'add', 'http://127.0.0.1:8080/static/example.com.html'], capture_output=True)
+    remove_process = subprocess.run(['archivebox', 'remove', '127.0.0.1:8080/static/example.com.html', '--yes'], capture_output=True)
+    list_process = subprocess.run(['archivebox', 'list'], capture_output=True)
+    assert "Warning: SQL index does not match JSON index!" not in list_process.stderr.decode("utf-8")


### PR DESCRIPTION
# Summary

When using `archivebox remove link`, it was not being removed from the sql index.

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
