### PR TITLE
fix: Guess timestamps and add placeholders to support older indices

### DIFF
--- a/archivebox/index/__init__.py
+++ b/archivebox/index/__init__.py
@@ -529,8 +529,16 @@ def get_unrecognized_folders(links, out_dir: str=OUTPUT_DIR) -> Dict[str, Option
             link = None
             try:
                 link = parse_json_link_details(entry.path)
-            except Exception:
-                pass
+            except KeyError:
+                # Try to fix index
+                if index_exists:
+                    try:
+                        # Last attempt to repair the detail index
+                        link_guessed = parse_json_link_details(entry.path, guess=True)
+                        write_json_link_details(link_guessed, out_dir=entry.path)
+                        link = parse_json_link_details(entry.path)
+                    except Exception as e:
+                        pass
 
             if index_exists and link is None:
                 # index exists but it's corrupted or unparseable
@@ -555,9 +563,9 @@ def is_valid(link: Link) -> bool:
         return False
     if dir_exists and index_exists:
         try:
-            parsed_link = parse_json_link_details(link.link_dir)
+            parsed_link = parse_json_link_details(link.link_dir, guess=True)
             return link.url == parsed_link.url
-        except Exception:
+        except Exception as e:
             pass
     return False
 

--- a/archivebox/index/schema.py
+++ b/archivebox/index/schema.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, asdict, field, fields
 
 from ..system import get_dir_size
 
+from ..config import OUTPUT_DIR, ARCHIVE_DIR_NAME
+
 class ArchiveError(Exception):
     def __init__(self, message, hints=None):
         super().__init__(message)
@@ -76,7 +78,7 @@ class ArchiveResult:
                 info['start_ts'] = parse_date(info['start_ts'])
                 info['end_ts'] = parse_date(info['end_ts'])
             if "pwd" not in keys:
-                info["pwd"] = str(os.getcwd() / Path(f"archive/{json_info['timestamp']}"))
+                info["pwd"] = str(Path(OUTPUT_DIR) / ARCHIVE_DIR_NAME / json_info["timestamp"])
             if "cmd_version" not in keys:
                 info["cmd_version"] = "Undefined"
             if "cmd" not in keys:


### PR DESCRIPTION
# Summary

Index loading is more liberal now. Instead of failing, it will attempt to repair the found files by extracting the timestamp from the `duration` and `timestamp` fields. Other values are just marked as `undefined`.
This should not affect up to date indexes. Old indexes, however, should get rewritten with the new information.

**Related issues: #374 

# Changes these areas

- [X] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
