### PR TITLE
ensure correct permissions for archived items

### DIFF
--- a/archivebox/system.py
+++ b/archivebox/system.py
@@ -57,7 +57,6 @@ def chmod_file(path: str, cwd: str='.', permissions: str=OUTPUT_PERMISSIONS) -> 
         os.chmod(root, int(OUTPUT_PERMISSIONS, base=8))
     else:
         for subpath in Path(path).glob('**/*'):
-            print("THE PATH TO MODIFY IS", subpath)
             os.chmod(subpath, int(OUTPUT_PERMISSIONS, base=8))
 
 

--- a/archivebox/system.py
+++ b/archivebox/system.py
@@ -53,8 +53,12 @@ def chmod_file(path: str, cwd: str='.', permissions: str=OUTPUT_PERMISSIONS) -> 
     if not root.exists():
         raise Exception('Failed to chmod: {} does not exist (did the previous step fail?)'.format(path))
 
-    for subpath in Path(path).glob('**/*'):
-        os.chmod(subpath, int(OUTPUT_PERMISSIONS, base=8))
+    if not root.is_dir():
+        os.chmod(root, int(OUTPUT_PERMISSIONS, base=8))
+    else:
+        for subpath in Path(path).glob('**/*'):
+            print("THE PATH TO MODIFY IS", subpath)
+            os.chmod(subpath, int(OUTPUT_PERMISSIONS, base=8))
 
 
 @enforce_types

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -51,3 +51,11 @@ def test_correct_permissions_output_folder(tmp_path, process):
         file_path = tmp_path / file
         assert oct(file_path.stat().st_mode)[-3:] == OUTPUT_PERMISSIONS
 
+def test_correct_permissions_add_command_results(tmp_path, process):
+    os.chdir(tmp_path)
+    add_process = subprocess.run(['archivebox', 'add', 'http://127.0.0.1:8080/static/example.com.html'], capture_output=True)
+    archived_item_path = list(tmp_path.glob('archive/**/*'))[0]
+    for path in archived_item_path.iterdir():
+        assert oct(path.stat().st_mode)[-3:] == OUTPUT_PERMISSIONS
+
+


### PR DESCRIPTION
# Summary

Ensure permissions inside an archived item's output is correct + test.

**Related issues: #377 

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
