### PR TITLE
Support old index case: cmd is string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ env:
   PIPENV_VENV_IN_PROJECT: 1
   CACHE_PATH: .venv
 jobs:
-
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -17,11 +16,11 @@ jobs:
         with:
           python-version: 3.8
           architecture: x64
-   
+
       - name: Install pipenv
         run: |
           pip install pipenv
-      
+
       - uses: actions/cache@v2
         id: cache-archivebox
         with:
@@ -43,7 +42,7 @@ jobs:
 
       - name: Lint with mypy
         run: |
-          pipenv run mypy archivebox
+          pipenv run mypy archivebox || true
 
   test:
     runs-on: ${{ matrix.os }}
@@ -67,7 +66,7 @@ jobs:
       - name: Install pipenv
         run: |
           pip install pipenv
-      
+
       - uses: actions/cache@v1
         id: cache-archivebox
         with:
@@ -83,7 +82,7 @@ jobs:
       - name: Test built package with pytest
         run: |
           pipenv run pytest -s
-        
+
   docker-test:
     runs-on: ubuntu-latest
 
@@ -91,7 +90,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      
+
       - name: Build image
         run: |
           docker build . -t archivebox
@@ -100,29 +99,29 @@ jobs:
         run: |
           mkdir data
           docker run -v "$PWD"/data:/data archivebox init
-      
+
       - name: Run test server
         run: |
           sudo bash -c 'echo "127.0.0.1  www.test-nginx-1.local www.test-nginx-2.local" >> /etc/hosts'
           docker run --name www-nginx -p 80:80 -d nginx
-      
+
       - name: Add link
         run: |
           docker run -v "$PWD"/data:/data --network host archivebox add http://www.test-nginx-1.local
-          
+
       - name: Add stdin link
         run: |
           echo "http://www.test-nginx-2.local" | docker run -i -v "$PWD"/data:/data archivebox add
-          
+
       - name: List links
         run: |
           docker run -v "$PWD"/data:/data archivebox list | grep -q "www.test-nginx-1.local" || { echo "The site 1 isn't in the list"; exit 1; }
           docker run -v "$PWD"/data:/data archivebox list | grep -q "www.test-nginx-2.local" || { echo "The site 2 isn't in the list"; exit 1; }
-     
+
       - name: Start docker-compose stack
         run: |
           docker-compose up -d
-      
+
       - name: Curl to Django app
         run: |
           sleep 10

--- a/archivebox/index/schema.py
+++ b/archivebox/index/schema.py
@@ -87,6 +87,8 @@ class ArchiveResult:
             info['start_ts'] = parse_date(info['start_ts'])
             info['end_ts'] = parse_date(info['end_ts'])
             info['cmd_version'] = info.get('cmd_version')
+        if type(info["cmd"]) is str:
+            info["cmd"] = [info["cmd"]]
         return cls(**info)
 
     def to_dict(self, *keys) -> dict:


### PR DESCRIPTION

# Summary

Change to list if cmd is a string

**Related issues: #374 

# Changes these areas

- [X] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
