### PR TITLE
Delete isolated quote in ArchiveBox.conf.default

### DIFF
--- a/etc/ArchiveBox.conf.default
+++ b/etc/ArchiveBox.conf.default
@@ -54,7 +54,7 @@
 # USE_GIT = True
 
 # CURL_BINARY = curl
-# GIT_BINARY = git"
+# GIT_BINARY = git
 # WGET_BINARY = wget
 # YOUTUBEDL_BINARY = youtube-dl
 # CHROME_BINARY = chromium


### PR DESCRIPTION
**IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes, I will close them with great prejudice.  The PEP8 checks I don't follow are intentional. PRs for minor bugfixes, typos, etc are fine.**

# Summary

There is an isolated quote introduce in commit https://github.com/pirate/ArchiveBox/commit/4d6ad7a65dc014a2ed4429401f11c4f8ec6305c1#diff-a0d96f90b24495fbbd701cfc0d94b192R53

This PR just simply delete the quote.

```diff
- #GIT_BINARY="git"
+ # GIT_BINARY = git"
```

# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
