### PR TITLE
Oneshot command

### DIFF
--- a/archivebox/cli/archivebox_oneshot.py
+++ b/archivebox/cli/archivebox_oneshot.py
@@ -47,7 +47,7 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
     stdin_url = accept_stdin(stdin)
     if (stdin_url and url) or (not stdin and not url):
         stderr(
-            '[X] You must pass URLs/paths to add via stdin or CLI arguments.\n',
+            '[X] You must pass URL/path to add via stdin or CLI arguments.\n',
             color='red',
         )
         raise SystemExit(2)

--- a/archivebox/cli/archivebox_oneshot.py
+++ b/archivebox/cli/archivebox_oneshot.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+__package__ = 'archivebox.cli'
+__command__ = 'archivebox oneshot'
+
+import sys
+import argparse
+
+from pathlib import Path
+from typing import List, Optional, IO
+
+from ..main import oneshot
+from ..util import docstring
+from ..config import OUTPUT_DIR
+from ..logging_util import SmartFormatter, accept_stdin, stderr
+
+
+@docstring(oneshot.__doc__)
+def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional[str]=None) -> None:
+    parser = argparse.ArgumentParser(
+        prog=__command__,
+        description=oneshot.__doc__,
+        add_help=True,
+        formatter_class=SmartFormatter,
+    )
+    parser.add_argument(
+        'url',
+        type=str,
+        default=None,
+        help=(
+            'URLs or paths to archive e.g.:\n'
+            '    https://getpocket.com/users/USERNAME/feed/all\n'
+            '    https://example.com/some/rss/feed.xml\n'
+            '    https://example.com\n'
+            '    ~/Downloads/firefox_bookmarks_export.html\n'
+            '    ~/Desktop/sites_list.csv\n'
+        )
+    )
+    parser.add_argument(
+        '--out-dir',
+        type=str,
+        default=OUTPUT_DIR,
+        help= "Path to save the single archive folder to, e.g. ./example.com_archive"
+    )
+    command = parser.parse_args(args or ())
+    url = command.url
+    stdin_url = accept_stdin(stdin)
+    if (stdin_url and url) or (not stdin and not url):
+        stderr(
+            '[X] You must pass URLs/paths to add via stdin or CLI arguments.\n',
+            color='red',
+        )
+        raise SystemExit(2)
+    
+    oneshot(
+        url=stdin_url or url,
+        out_dir=str(Path(command.out_dir).absolute()),
+    )
+
+
+if __name__ == '__main__':
+    main(args=sys.argv[1:], stdin=sys.stdin)

--- a/archivebox/cli/archivebox_oneshot.py
+++ b/archivebox/cli/archivebox_oneshot.py
@@ -47,7 +47,7 @@ def main(args: Optional[List[str]]=None, stdin: Optional[IO]=None, pwd: Optional
     stdin_url = accept_stdin(stdin)
     if (stdin_url and url) or (not stdin and not url):
         stderr(
-            '[X] You must pass URL/path to add via stdin or CLI arguments.\n',
+            '[X] You must pass a URL/path to add via stdin or CLI arguments.\n',
             color='red',
         )
         raise SystemExit(2)

--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -123,7 +123,7 @@ def archive_link(link: Link, overwrite: bool=False, methods: Optional[Iterable[s
 
 
 @enforce_types
-def archive_links(links: List[Link], overwrite: bool=False, methods: Optional[Iterable[str]]=None, out_dir: Optional[str]=None, skip_index: bool=False, oneshot: bool=False) -> List[Link]:
+def archive_links(links: List[Link], overwrite: bool=False, methods: Optional[Iterable[str]]=None, out_dir: Optional[str]=None) -> List[Link]:
     if not links:
         return []
 
@@ -132,11 +132,7 @@ def archive_links(links: List[Link], overwrite: bool=False, methods: Optional[It
     link: Link = links[0]
     try:
         for idx, link in enumerate(links):
-            if oneshot:
-                link_out_dir = out_dir or link.link_dir
-            else:
-                link_out_dir = link.link_dir
-            archive_link(link, overwrite=overwrite, methods=methods, out_dir=link_out_dir, skip_index=skip_index)
+            archive_link(link, overwrite=overwrite, methods=methods, out_dir=link.link_dir)
     except KeyboardInterrupt:
         log_archiving_paused(len(links), idx, link.timestamp)
         raise SystemExit(0)

--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -32,22 +32,32 @@ from .git import should_save_git, save_git
 from .media import should_save_media, save_media
 from .archive_org import should_save_archive_dot_org, save_archive_dot_org
 
+def get_default_archive_methods():
+    return [
+            ('title', should_save_title, save_title),
+            ('favicon', should_save_favicon, save_favicon),
+            ('wget', should_save_wget, save_wget),
+            ('pdf', should_save_pdf, save_pdf),
+            ('screenshot', should_save_screenshot, save_screenshot),
+            ('dom', should_save_dom, save_dom),
+            ('git', should_save_git, save_git),
+            ('media', should_save_media, save_media),
+            ('archive_org', should_save_archive_dot_org, save_archive_dot_org),
+        ]
+
+@enforce_types
+def ignore_methods(to_ignore: List[str]):
+    ARCHIVE_METHODS = get_default_archive_methods()
+    methods = filter(lambda x: x[0] not in to_ignore, ARCHIVE_METHODS)
+    methods = map(lambda x: x[1], methods)
+    return list(methods)
 
 @enforce_types
 def archive_link(link: Link, overwrite: bool=False, methods: Optional[Iterable[str]]=None, out_dir: Optional[str]=None, skip_index: bool=False) -> Link:
     """download the DOM, PDF, and a screenshot into a folder named after the link's timestamp"""
 
-    ARCHIVE_METHODS = [
-        ('title', should_save_title, save_title),
-        ('favicon', should_save_favicon, save_favicon),
-        ('wget', should_save_wget, save_wget),
-        ('pdf', should_save_pdf, save_pdf),
-        ('screenshot', should_save_screenshot, save_screenshot),
-        ('dom', should_save_dom, save_dom),
-        ('git', should_save_git, save_git),
-        ('media', should_save_media, save_media),
-        ('archive_org', should_save_archive_dot_org, save_archive_dot_org),
-    ]
+    ARCHIVE_METHODS = get_default_archive_methods()
+    
     if methods is not None:
         ARCHIVE_METHODS = [
             method for method in ARCHIVE_METHODS

--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -123,7 +123,7 @@ def archive_link(link: Link, overwrite: bool=False, methods: Optional[Iterable[s
 
 
 @enforce_types
-def archive_links(links: List[Link], overwrite: bool=False, methods: Optional[Iterable[str]]=None, out_dir: Optional[str]=None, skip_index: bool=False) -> List[Link]:
+def archive_links(links: List[Link], overwrite: bool=False, methods: Optional[Iterable[str]]=None, out_dir: Optional[str]=None, skip_index: bool=False, oneshot: bool=False) -> List[Link]:
     if not links:
         return []
 
@@ -132,8 +132,11 @@ def archive_links(links: List[Link], overwrite: bool=False, methods: Optional[It
     link: Link = links[0]
     try:
         for idx, link in enumerate(links):
-            link_out_dir = out_dir or link.link_dir
-            archive_link(link, overwrite=overwrite, methods=methods, link_out_dir=out_dir, skip_index=skip_index)
+            if oneshot:
+                link_out_dir = out_dir or link.link_dir
+            else:
+                link_out_dir = link.link_dir
+            archive_link(link, overwrite=overwrite, methods=methods, out_dir=link_out_dir, skip_index=skip_index)
     except KeyboardInterrupt:
         log_archiving_paused(len(links), idx, link.timestamp)
         raise SystemExit(0)

--- a/archivebox/index/__init__.py
+++ b/archivebox/index/__init__.py
@@ -354,12 +354,13 @@ def patch_main_index(link: Link, out_dir: str=OUTPUT_DIR) -> None:
 ### Link Details Index
 
 @enforce_types
-def write_link_details(link: Link, out_dir: Optional[str]=None) -> None:
+def write_link_details(link: Link, out_dir: Optional[str]=None, skip_sql_index: bool=False) -> None:
     out_dir = out_dir or link.link_dir
 
     write_json_link_details(link, out_dir=out_dir)
     write_html_link_details(link, out_dir=out_dir)
-    write_sql_link_details(link)
+    if not skip_sql_index:
+        write_sql_link_details(link)
 
 
 @enforce_types

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -498,7 +498,7 @@ def status(out_dir: str=OUTPUT_DIR) -> None:
 def oneshot(url: str, out_dir: str=OUTPUT_DIR):
     oneshot_links, _ = parse_links_memory([url])
     oneshot_links, _ = dedupe_links([], oneshot_links)
-    archive_links(oneshot_links, out_dir=out_dir, skip_index=True)
+    archive_links(oneshot_links, out_dir=out_dir, skip_index=True, oneshot=True)
     return oneshot_links
 
 @enforce_types

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -18,6 +18,7 @@ from .cli import (
 from .parsers import (
     save_text_as_source,
     save_file_as_source,
+    parse_links_memory,
 )
 from .index.schema import Link
 from .util import enforce_types                         # type: ignore
@@ -492,6 +493,13 @@ def status(out_dir: str=OUTPUT_DIR) -> None:
         )
     print(ANSI['black'], '   ...', ANSI['reset'])
 
+
+@enforce_types
+def oneshot(url: str, out_dir: str=OUTPUT_DIR):
+    oneshot_links, _ = parse_links_memory([url])
+    oneshot_links, _ = dedupe_links([], oneshot_links)
+    archive_links(oneshot_links, out_dir=out_dir, skip_index=True)
+    return oneshot_links
 
 @enforce_types
 def add(urls: Union[str, List[str]],
@@ -1055,3 +1063,4 @@ def shell(out_dir: str=OUTPUT_DIR) -> None:
     setup_django(OUTPUT_DIR)
     from django.core.management import call_command
     call_command("shell_plus")
+

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -52,7 +52,7 @@ from .index.sql import (
     remove_from_sql_main_index,
 )
 from .index.html import parse_html_main_index
-from .extractors import archive_links
+from .extractors import archive_links, archive_link
 from .config import (
     stderr,
     ConfigDict,
@@ -496,10 +496,15 @@ def status(out_dir: str=OUTPUT_DIR) -> None:
 
 @enforce_types
 def oneshot(url: str, out_dir: str=OUTPUT_DIR):
-    oneshot_links, _ = parse_links_memory([url])
-    oneshot_links, _ = dedupe_links([], oneshot_links)
-    archive_links(oneshot_links, out_dir=out_dir, skip_index=True, oneshot=True)
-    return oneshot_links
+    oneshot_link, _ = parse_links_memory([url])
+    if len(oneshot_link) > 1:
+        stderr(
+                '[X] You should pass a single url to the oneshot command',
+                color='red'
+            )
+        raise SystemExit(2)
+    archive_link(oneshot_link[0], out_dir=out_dir, skip_index=True)
+    return oneshot_link
 
 @enforce_types
 def add(urls: Union[str, List[str]],

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -52,7 +52,7 @@ from .index.sql import (
     remove_from_sql_main_index,
 )
 from .index.html import parse_html_main_index
-from .extractors import archive_links, archive_link
+from .extractors import archive_links, archive_link, ignore_methods
 from .config import (
     stderr,
     ConfigDict,
@@ -503,7 +503,8 @@ def oneshot(url: str, out_dir: str=OUTPUT_DIR):
                 color='red'
             )
         raise SystemExit(2)
-    archive_link(oneshot_link[0], out_dir=out_dir, skip_index=True)
+    methods = ignore_methods(['title'])
+    archive_link(oneshot_link[0], out_dir=out_dir, methods=methods, skip_index=True)
     return oneshot_link
 
 @enforce_types

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -496,6 +496,10 @@ def status(out_dir: str=OUTPUT_DIR) -> None:
 
 @enforce_types
 def oneshot(url: str, out_dir: str=OUTPUT_DIR):
+    """
+    Create a single URL archive folder with an index.json and index.html, and all the archive method outputs.
+    You can run this to archive single pages without needing to create a whole collection with archivebox init.
+    """
     oneshot_link, _ = parse_links_memory([url])
     if len(oneshot_link) > 1:
         stderr(

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,5 +1,13 @@
 from .fixtures import *
+from archivebox.extractors import ignore_methods, get_default_archive_methods, should_save_title
 
 def test_wget_broken_pipe(tmp_path, process):
     add_process = subprocess.run(['archivebox', 'add', 'http://127.0.0.1:8080/static/example.com.html'], capture_output=True)
     assert "TypeError chmod_file(..., path: str) got unexpected NoneType argument path=None" not in add_process.stdout.decode("utf-8")
+
+def test_ignore_methods():
+    """
+    Takes the passed method out of the default methods list and returns that value
+    """
+    ignored = ignore_methods(['title'])
+    assert should_save_title not in ignored

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -1,0 +1,12 @@
+from .fixtures import *
+
+def test_oneshot_command_exists(tmp_path):
+    os.chdir(tmp_path)
+    process = subprocess.run(['archivebox', 'oneshot'], capture_output=True)
+    assert not "invalid choice: 'oneshot'" in process.stderr.decode("utf-8")
+
+def test_oneshot_commad_saves_page_in_right_folder(tmp_path):
+    process = subprocess.run(["archivebox", "oneshot", f"--out-dir={tmp_path}", "http://127.0.0.1:8080/static/example.com.html"], capture_output=True)
+    items = ' '.join([str(x) for x in tmp_path.iterdir()])
+    assert "index.json" in items
+    

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from .fixtures import *
 
 def test_oneshot_command_exists(tmp_path):
@@ -8,5 +10,7 @@ def test_oneshot_command_exists(tmp_path):
 def test_oneshot_commad_saves_page_in_right_folder(tmp_path):
     process = subprocess.run(["archivebox", "oneshot", f"--out-dir={tmp_path}", "http://127.0.0.1:8080/static/example.com.html"], capture_output=True)
     items = ' '.join([str(x) for x in tmp_path.iterdir()])
+    current_path = ' '.join([str(x) for x in Path.cwd().iterdir()])
     assert "index.json" in items
+    assert not "index.sqlite3" in current_path
     


### PR DESCRIPTION
# Summary

Progress to get a functional `oneshot` command. It is not perfect yet, but I want to get an early review and feedback on the remaining issues.
Currently, I see 2 issues, which are related:
- The title extractor is failing because if depends on the sqlite database. We either change that (or disable it partially with a flag) or guarantee the sqlite database is correct.
- The process above is creating a blank sqlite3 database in the `out_dir`

The general issue with this command, is that OUTPUT_DIR is used everywhere, so overriding it is not trivial.

# Changes these areas

- [ ] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

# Roadmap Goals

https://github.com/pirate/ArchiveBox/wiki/Roadmap#-archivebox-oneshot
