### PR TITLE
Typo - CHROME was spelled CROME x2

### DIFF
--- a/etc/ArchiveBox.conf.default
+++ b/etc/ArchiveBox.conf.default
@@ -60,5 +60,5 @@
 # CHROME_BINARY = chromium
 
 # CHROME_USER_DATA_DIR="~/.config/google-chrome/Default"
-# CROME_HEADLESS = True
-# CROME_SANDBOX = True
+# CHROME_HEADLESS = True
+# CHROME_SANDBOX = True


### PR DESCRIPTION
**IMPORTANT: Do not submit PRs with only formatting / PEP8 / line length changes, I will close them with great prejudice.  The PEP8 checks I don't follow are intentional. PRs for minor bugfixes, typos, etc are fine.**

# Summary

CHROME was spelled CROME in two places.

**Related issues: #XYZ** (delete this line if there are no related issues)

# Changes these areas

- [ X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

# Roadmap Goals

This PR helps us move towards xyz roadmap goal, as outlined here: https://github.com/pirate/ArchiveBox#roadmap
(delete this section if it's just a bugfix / simple PR)
