### PR TITLE
feat: Check page responsiveness before trying to archive it

### DIFF
--- a/archivebox/util.py
+++ b/archivebox/util.py
@@ -174,6 +174,13 @@ def download_url(url: str, timeout: int=None) -> str:
 
 
 @enforce_types
+def check_page_responsive(url: str) -> bool:
+    try:
+        return requests.head(url).status_code < 400
+    except:
+        return False
+
+@enforce_types
 def chrome_args(**options) -> List[str]:
     """helper to build up a chrome shell command with arguments"""
 

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -21,3 +21,9 @@ def test_singlefile_works(tmp_path, process, disable_extractors_dict):
     archived_item_path = list(tmp_path.glob('archive/**/*'))[0]
     output_file = archived_item_path / "singlefile.html" 
     assert output_file.exists()
+
+
+def test_unreachable_url_fails(tmp_path, process):
+    add_process = subprocess.run(["archivebox", "add", "http://127.0.0.1:8080/this-url-does-not-exist"],
+                                   capture_output=True)
+    assert "Unreachable URL" in add_process.stdout.decode("utf-8")


### PR DESCRIPTION
# Summary

Run a `HEAD` request before trying to archive. Skip archiving and add failed + 1 to stats in the case that the status code is > 400 or there is an exception.

**Related issues: #209 

# Changes these areas

- [ ] Bugfixes
- [X] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk
