### PR TITLE
fix: Add a default cmd

### DIFF
--- a/archivebox/extractors/readability.py
+++ b/archivebox/extractors/readability.py
@@ -16,6 +16,7 @@ from ..util import (
 )
 from ..config import (
     TIMEOUT,
+    CURL_BINARY,
     SAVE_READABILITY,
     DEPENDENCIES,
     READABILITY_VERSION,
@@ -65,7 +66,10 @@ def save_readability(link: Link, out_dir: Optional[str]=None, timeout: int=TIMEO
     # Readability Docs: https://github.com/mozilla/readability
 
     status = 'succeeded'
-    cmd = []
+    cmd = [
+        CURL_BINARY,
+        link.url
+    ]
     timer = TimedProgress(timeout, prefix='      ')
     try:
         document = get_html(link, out_dir)

--- a/archivebox/extractors/readability.py
+++ b/archivebox/extractors/readability.py
@@ -66,6 +66,7 @@ def save_readability(link: Link, out_dir: Optional[str]=None, timeout: int=TIMEO
     # Readability Docs: https://github.com/mozilla/readability
 
     status = 'succeeded'
+    # fake command to show the user so they have something to try debugging if get_html fails
     cmd = [
         CURL_BINARY,
         link.url

--- a/archivebox/extractors/readability.py
+++ b/archivebox/extractors/readability.py
@@ -65,6 +65,7 @@ def save_readability(link: Link, out_dir: Optional[str]=None, timeout: int=TIMEO
     # Readability Docs: https://github.com/mozilla/readability
 
     status = 'succeeded'
+    cmd = []
     timer = TimedProgress(timeout, prefix='      ')
     try:
         document = get_html(link, out_dir)


### PR DESCRIPTION
# Summary

When the html cannot be retrieved (timeout, unreachable, etc), the cmd value is not set, which causes archivebox to crash. Adding a default value should be enough in that case. 

**Related issues: #458 
# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

