### PR TITLE
fix: Escape JSON output on singlefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ venv/
 
 build/
 dist/
+node_modules/
 
 data/
 output/

--- a/archivebox/extractors/singlefile.py
+++ b/archivebox/extractors/singlefile.py
@@ -42,10 +42,11 @@ def save_singlefile(link: Link, out_dir: Optional[str]=None, timeout: int=TIMEOU
     browser_args = chrome_args(TIMEOUT=0)
 
     # SingleFile CLI Docs: https://github.com/gildas-lormeau/SingleFile/tree/master/cli
+    browser_args = '--browser-args={}'.format(json.dumps(browser_args[1:]))
     cmd = [
         DEPENDENCIES['SINGLEFILE_BINARY']['path'],
         '--browser-executable-path={}'.format(CHROME_BINARY),
-        '--browser-args="{}"'.format(json.dumps(browser_args[1:])),
+        browser_args,
         link.url,
         output
     ]
@@ -73,6 +74,8 @@ def save_singlefile(link: Link, out_dir: Optional[str]=None, timeout: int=TIMEOU
         chmod_file(output)
     except (Exception, OSError) as err:
         status = 'failed'
+        # TODO: Make this prettier. This is necessary to run the command (escape JSON internal quotes).
+        cmd[2] = browser_args.replace('"', "\\\"")
         output = err
     finally:
         timer.end()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "archivebox",
-	"version": "0.4.19",
+	"version": "0.4.21",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
# Summary

Manually escape json output so the user can run it in the command line after the command fails.

**Related issues: #463 

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

