### PR TITLE
Feature: Add @postlight/mercury-parser as an alternative to Readability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,7 @@ jobs:
           npm install
           echo "::set-env name=SINGLEFILE_BINARY::$GITHUB_WORKSPACE/node_modules/.bin/single-file"
           echo "::set-env name=READABILITY_BINARY::$GITHUB_WORKSPACE/node_modules/.bin/readability-extractor"
+          echo "::set-env name=MERCURY_BINARY::$GITHUB_WORKSPACE/node_modules/.bin/mercury-parser"
 
 
       ### Run the tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,9 @@ ENV IN_DOCKER=True \
     USE_SINGLEFILE=True \
     SINGLEFILE_BINARY="$NODE_DIR/node_modules/.bin/single-file" \
     USE_READABILITY=True \
-    READABILITY_BINARY="$NODE_DIR/node_modules/.bin/readability-extractor"
+    READABILITY_BINARY="$NODE_DIR/node_modules/.bin/readability-extractor" \
+    USE_MERCURY=True \
+    MERCURY_BINARY="$NODE_DIR/node_modules/.bin/mercury-parser"
 
 # Print version for nice docker finish summary
 RUN archivebox version

--- a/archivebox/config/__init__.py
+++ b/archivebox/config/__init__.py
@@ -81,6 +81,7 @@ CONFIG_DEFAULTS: Dict[str, ConfigDefaultDict] = {
         'SAVE_WGET_REQUISITES':     {'type': bool,  'default': True, 'aliases': ('FETCH_WGET_REQUISITES',)},
         'SAVE_SINGLEFILE':          {'type': bool,  'default': True, 'aliases': ('FETCH_SINGLEFILE',)},
         'SAVE_READABILITY':         {'type': bool,  'default': True, 'aliases': ('FETCH_READABILITY',)},
+        'SAVE_MERCURY':             {'type': bool,  'default': True, 'aliases': ('FETCH_MERCURY',)},
         'SAVE_PDF':                 {'type': bool,  'default': True, 'aliases': ('FETCH_PDF',)},
         'SAVE_SCREENSHOT':          {'type': bool,  'default': True, 'aliases': ('FETCH_SCREENSHOT',)},
         'SAVE_DOM':                 {'type': bool,  'default': True, 'aliases': ('FETCH_DOM',)},
@@ -112,6 +113,7 @@ CONFIG_DEFAULTS: Dict[str, ConfigDefaultDict] = {
         'USE_WGET':                 {'type': bool,  'default': True},
         'USE_SINGLEFILE':           {'type': bool,  'default': True},
         'USE_READABILITY':          {'type': bool,  'default': True},
+        'USE_MERCURY':              {'type': bool,  'default': True},
         'USE_GIT':                  {'type': bool,  'default': True},
         'USE_CHROME':               {'type': bool,  'default': True},
         'USE_NODE':                 {'type': bool,  'default': True},
@@ -122,6 +124,7 @@ CONFIG_DEFAULTS: Dict[str, ConfigDefaultDict] = {
         'WGET_BINARY':              {'type': str,   'default': 'wget'},
         'SINGLEFILE_BINARY':        {'type': str,   'default': 'single-file'},
         'READABILITY_BINARY':       {'type': str,   'default': 'readability-extractor'},
+        'MERCURY_BINARY':           {'type': str,   'default': 'mercury-parser'},
         'YOUTUBEDL_BINARY':         {'type': str,   'default': 'youtube-dl'},
         'CHROME_BINARY':            {'type': str,   'default': None},
     },
@@ -265,6 +268,9 @@ DERIVED_CONFIG_DEFAULTS: ConfigDefaultDict = {
     'USE_READABILITY':          {'default': lambda c: c['USE_READABILITY'] and c['SAVE_READABILITY']},
     'READABILITY_VERSION':      {'default': lambda c: bin_version(c['READABILITY_BINARY']) if c['USE_READABILITY'] else None},
 
+    'USE_MERCURY':              {'default': lambda c: c['USE_MERCURY'] and c['SAVE_MERCURY']},
+    'MERCURY_VERSION':          {'default': lambda c: bin_version(c['MERCURY_BINARY']) if c['USE_MERCURY'] else None},
+
     'USE_GIT':                  {'default': lambda c: c['USE_GIT'] and c['SAVE_GIT']},
     'GIT_VERSION':              {'default': lambda c: bin_version(c['GIT_BINARY']) if c['USE_GIT'] else None},
     'SAVE_GIT':                 {'default': lambda c: c['USE_GIT'] and c['SAVE_GIT']},
@@ -283,6 +289,7 @@ DERIVED_CONFIG_DEFAULTS: ConfigDefaultDict = {
     'SAVE_DOM':                 {'default': lambda c: c['USE_CHROME'] and c['SAVE_DOM']},
     'SAVE_SINGLEFILE':          {'default': lambda c: c['USE_CHROME'] and c['USE_SINGLEFILE'] and c['USE_NODE']},
     'SAVE_READABILITY':         {'default': lambda c: c['USE_READABILITY'] and c['USE_NODE']},
+    'SAVE_MERCURY':             {'default': lambda c: c['USE_MERCURY'] and c['USE_NODE']},
 
     'DEPENDENCIES':             {'default': lambda c: get_dependency_info(c)},
     'CODE_LOCATIONS':           {'default': lambda c: get_code_locations(c)},
@@ -727,6 +734,13 @@ def get_dependency_info(config: ConfigDict) -> ConfigValue:
             'hash': bin_hash(config['READABILITY_BINARY']),
             'enabled': config['USE_READABILITY'],
             'is_valid': bool(config['READABILITY_VERSION']),
+        },
+        'MERCURY_BINARY': {
+            'path': bin_path(config['MERCURY_BINARY']),
+            'version': config['MERCURY_VERSION'],
+            'hash': bin_hash(config['MERCURY_BINARY']),
+            'enabled': config['USE_MERCURY'],
+            'is_valid': bool(config['MERCURY_VERSION']),
         },
         'GIT_BINARY': {
             'path': bin_path(config['GIT_BINARY']),

--- a/archivebox/config/stubs.py
+++ b/archivebox/config/stubs.py
@@ -57,6 +57,7 @@ class ConfigDict(BaseConfig, total=False):
     SAVE_WGET_REQUISITES: bool
     SAVE_SINGLEFILE: bool
     SAVE_READABILITY: bool
+    SAVE_MERCURY: bool
     SAVE_PDF: bool
     SAVE_SCREENSHOT: bool
     SAVE_DOM: bool
@@ -81,6 +82,7 @@ class ConfigDict(BaseConfig, total=False):
     USE_WGET: bool
     USE_SINGLEFILE: bool
     USE_READABILITY: bool
+    USE_MERCURY: bool
     USE_GIT: bool
     USE_CHROME: bool
     USE_YOUTUBEDL: bool
@@ -89,6 +91,7 @@ class ConfigDict(BaseConfig, total=False):
     WGET_BINARY: str
     SINGLEFILE_BINARY: str
     READABILITY_BINARY: str
+    MERCURY_BINARY: str
     YOUTUBEDL_BINARY: str
     CHROME_BINARY: Optional[str]
 

--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -28,6 +28,7 @@ from .favicon import should_save_favicon, save_favicon
 from .wget import should_save_wget, save_wget
 from .singlefile import should_save_singlefile, save_singlefile
 from .readability import should_save_readability, save_readability
+from .mercury import should_save_mercury, save_mercury
 from .pdf import should_save_pdf, save_pdf
 from .screenshot import should_save_screenshot, save_screenshot
 from .dom import should_save_dom, save_dom
@@ -45,6 +46,7 @@ def get_default_archive_methods():
         ('screenshot', should_save_screenshot, save_screenshot),
         ('dom', should_save_dom, save_dom),
         ('readability', should_save_readability, save_readability), #keep readability below wget and singlefile, as it depends on them
+        ('mercury', should_save_mercury, save_mercury),
         ('git', should_save_git, save_git),
         ('media', should_save_media, save_media),
         ('archive_org', should_save_archive_dot_org, save_archive_dot_org),

--- a/archivebox/extractors/mercury.py
+++ b/archivebox/extractors/mercury.py
@@ -1,0 +1,95 @@
+__package__ = 'archivebox.extractors'
+
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from typing import Optional
+import json
+
+from ..index.schema import Link, ArchiveResult, ArchiveError
+from ..system import run, atomic_write
+from ..util import (
+    enforce_types,
+    download_url,
+    is_static_file,
+
+)
+from ..config import (
+    TIMEOUT,
+    CURL_BINARY,
+    SAVE_MERCURY,
+    DEPENDENCIES,
+    MERCURY_VERSION,
+)
+from ..logging_util import TimedProgress
+
+@enforce_types
+def should_save_mercury(link: Link, out_dir: Optional[str]=None) -> bool:
+    out_dir = out_dir or link.link_dir
+    if is_static_file(link.url):
+        return False
+
+    output = Path(out_dir or link.link_dir) / 'mercury'
+    return SAVE_MERCURY and MERCURY_VERSION and (not output.exists())
+
+
+@enforce_types
+def save_mercury(link: Link, out_dir: Optional[str]=None, timeout: int=TIMEOUT) -> ArchiveResult:
+    """download reader friendly version using @postlight/mercury-parser"""
+
+    out_dir = Path(out_dir or link.link_dir)
+    output_folder = out_dir.absolute() / "mercury"
+    output = str(output_folder)
+
+    status = 'succeeded'
+    timer = TimedProgress(timeout, prefix='      ')
+    try:
+        cmd = [
+            DEPENDENCIES['MERCURY_BINARY']['path'],
+            link.url,
+            "--format=text"
+        ]
+        result = run(cmd, cwd=out_dir, timeout=timeout)
+        txtresult_json = json.loads(result.stdout)
+
+        cmd = [
+            DEPENDENCIES['MERCURY_BINARY']['path'],
+            link.url
+        ]
+        result = run(cmd, cwd=out_dir, timeout=timeout)
+        result_json = json.loads(result.stdout)
+
+        output_folder.mkdir(exist_ok=True)
+        atomic_write(str(output_folder / "content.html"), result_json.pop("content"))
+        atomic_write(str(output_folder / "content.txt"), txtresult_json["content"])
+        atomic_write(str(output_folder / "article.json"), result_json)
+
+        # parse out number of files downloaded from last line of stderr:
+        #  "Downloaded: 76 files, 4.0M in 1.6s (2.52 MB/s)"
+        output_tail = [
+            line.strip()
+            for line in (result.stdout + result.stderr).decode().rsplit('\n', 20)[-20:]
+            if line.strip()
+        ]
+        hints = (
+            'Got mercury response code: {}.'.format(result.returncode),
+            *output_tail,
+        )
+
+        # Check for common failure cases
+        if (result.returncode > 0):
+            raise ArchiveError('Mercury parser was not able to archive the page', hints)
+    except (Exception, OSError) as err:
+        status = 'failed'
+        output = err
+    finally:
+        timer.end()
+
+    return ArchiveResult(
+        cmd=cmd,
+        pwd=str(out_dir),
+        cmd_version=MERCURY_VERSION,
+        output=output,
+        status=status,
+        **timer.stats,
+    )

--- a/archivebox/index/schema.py
+++ b/archivebox/index/schema.py
@@ -408,6 +408,7 @@ class Link:
             'warc_path': 'warc',
             'singlefile_path': 'singlefile.html',
             'readability_path': 'readability/content.html',
+            'mercury_path': 'mercury/content.html',
             'pdf_path': 'output.pdf',
             'screenshot_path': 'screenshot.png',
             'dom_path': 'output.html',
@@ -429,6 +430,7 @@ class Link:
                 'dom_path': static_path,
                 'singlefile_path': static_path,
                 'readability_path': static_path,
+                'mercury_path': static_path,
             })
         return canonical
 

--- a/archivebox/themes/legacy/link_details.html
+++ b/archivebox/themes/legacy/link_details.html
@@ -413,6 +413,19 @@
                           </div>
                         </div>
                     </div>
+                    <br/>
+                    <div class="col-lg-3">
+                        <div class="card">
+                            <iframe class="card-img-top" src="$mercury_path" sandbox="allow-same-origin allow-scripts allow-forms" scrolling="no"></iframe>
+                            <div class="card-body">
+                                <a href="$mercury_path" style="float:right" title="Open in new tab..." target="_blank" rel="noopener">
+                                    <img src="../../static/external.png" class="external"/>
+                                </a>
+                                <a href="$mercury_path" target="preview"><h4 class="card-title">mercury</h4></a>
+                                <p class="card-text">archive/mercury/...</p>
+                          </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </header>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,117 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/runtime-corejs2": {
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz",
+			"integrity": "sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==",
+			"requires": {
+				"core-js": "^2.6.5",
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
 		"@mozilla/readability": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@mozilla/readability/-/readability-0.3.0.tgz",
 			"integrity": "sha512-q8f1CAZsRKK1j+O0BmikGIlKSK03RpT4woT0PCQwhw0nH0z4+rG026AkxoPcjT7Dsgh1ifGscW8tOpvjoyOjvw=="
+		},
+		"@postlight/ci-failed-test-reporter": {
+			"version": "1.0.26",
+			"resolved": "https://registry.npmjs.org/@postlight/ci-failed-test-reporter/-/ci-failed-test-reporter-1.0.26.tgz",
+			"integrity": "sha512-xfXzxyOiKhco7Gx2OLTe9b66b0dFJw0elg94KGHoQXf5F8JqqFvdo35J8wayGOor64CSMvn+4Bjlu2NKV+yTGA==",
+			"requires": {
+				"dotenv": "^6.2.0",
+				"node-fetch": "^2.3.0"
+			}
+		},
+		"@postlight/mercury-parser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@postlight/mercury-parser/-/mercury-parser-2.2.0.tgz",
+			"integrity": "sha512-nz6dIvCAaiv74o1vhhp0BRsUe+ysPbZG5mVNpJmgLoI/goOBqRMM3Yg8uXtnv++e7tzKFSXdls8b2/zKk1qL0Q==",
+			"requires": {
+				"@babel/runtime-corejs2": "^7.2.0",
+				"@postlight/ci-failed-test-reporter": "^1.0",
+				"browser-request": "github:postlight/browser-request#feat-add-headers-to-response",
+				"cheerio": "^0.22.0",
+				"difflib": "github:postlight/difflib.js",
+				"ellipsize": "0.1.0",
+				"iconv-lite": "0.5.0",
+				"jquery": "^3.4.1",
+				"moment": "^2.23.0",
+				"moment-parseformat": "3.0.0",
+				"moment-timezone": "0.5.26",
+				"postman-request": "^2.88.1-postman.7.1",
+				"request-promise": "^4.2.2",
+				"string-direction": "^0.1.2",
+				"turndown": "^5.0.3",
+				"url": "^0.11.0",
+				"valid-url": "^1.0.9",
+				"wuzzy": "^0.1.4",
+				"yargs-parser": "^13.0.0"
+			},
+			"dependencies": {
+				"http-headers": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"next-line": "^1.1.0"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
+					"integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3"
+					}
+				},
+				"jquery": {
+					"version": "3.4.1",
+					"bundled": true
+				},
+				"moment": {
+					"version": "2.23.0",
+					"bundled": true
+				},
+				"moment-timezone": {
+					"version": "0.5.26",
+					"bundled": true,
+					"requires": {
+						"moment": ">= 2.9.0"
+					}
+				},
+				"next-line": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"yargs-parser": {
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"@postman/form-data": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@postman/form-data/-/form-data-3.1.0.tgz",
+			"integrity": "sha512-6x1UHKQ45Sv5yLFjqhhtyk3YGOF9677RVRQjfr32Bkt45pH8yIlqcpPxiIR4/ZEs3GFk5vl5j9ymmdLTt0HR6Q==",
+			"requires": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"@postman/tunnel-agent": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@postman/tunnel-agent/-/tunnel-agent-0.6.3.tgz",
+			"integrity": "sha512-k57fzmAZ2PJGxfOA4SGR05ejorHbVAa/84Hxh/2nAztjNXc4ZjOm9NUIk6/Z6LCrBvJZqjRZbN8e/nROVUPVdg==",
+			"requires": {
+				"safe-buffer": "^5.0.1"
+			}
 		},
 		"@types/color-name": {
 			"version": "1.1.1",
@@ -83,6 +190,11 @@
 				"color-convert": "^2.0.1"
 			}
 		},
+		"array-equal": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
+		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -95,6 +207,11 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+		},
+		"async-limiter": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -139,6 +256,16 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"bluebird": {
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+			"integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+		},
+		"boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -148,10 +275,25 @@
 				"concat-map": "0.0.1"
 			}
 		},
+		"brotli": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
+			"integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
+			"requires": {
+				"base64-js": "^1.1.2"
+			}
+		},
 		"browser-process-hrtime": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+		},
+		"browser-request": {
+			"version": "github:postlight/browser-request#38faa5b85741aabfca61aa37d1ef044d68969ddf",
+			"from": "github:postlight/browser-request#feat-add-headers-to-response",
+			"requires": {
+				"http-headers": "^3.0.1"
+			}
 		},
 		"buffer": {
 			"version": "5.6.0",
@@ -176,6 +318,29 @@
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+		},
+		"cheerio": {
+			"version": "0.22.0",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+			"integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+			"requires": {
+				"css-select": "~1.2.0",
+				"dom-serializer": "~0.1.0",
+				"entities": "~1.1.1",
+				"htmlparser2": "^3.9.1",
+				"lodash.assignin": "^4.0.9",
+				"lodash.bind": "^4.1.4",
+				"lodash.defaults": "^4.0.1",
+				"lodash.filter": "^4.4.0",
+				"lodash.flatten": "^4.2.0",
+				"lodash.foreach": "^4.3.0",
+				"lodash.map": "^4.4.0",
+				"lodash.merge": "^4.4.0",
+				"lodash.pick": "^4.2.1",
+				"lodash.reduce": "^4.4.0",
+				"lodash.reject": "^4.4.0",
+				"lodash.some": "^4.4.0"
+			}
 		},
 		"chownr": {
 			"version": "1.1.4",
@@ -218,10 +383,31 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
+		"core-js": {
+			"version": "2.6.11",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"css-select": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+			"requires": {
+				"boolbase": "~1.0.0",
+				"css-what": "2.1",
+				"domutils": "1.5.1",
+				"nth-check": "~1.0.1"
+			}
+		},
+		"css-what": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
 		},
 		"cssom": {
 			"version": "0.4.4",
@@ -289,6 +475,27 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
+		"difflib": {
+			"version": "github:postlight/difflib.js#32e8e38c7fcd935241b9baab71bb432fd9b166ed",
+			"from": "github:postlight/difflib.js",
+			"requires": {
+				"heap": ">= 0.2.0"
+			}
+		},
+		"dom-serializer": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+			"requires": {
+				"domelementtype": "^1.3.0",
+				"entities": "^1.1.1"
+			}
+		},
+		"domelementtype": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+			"integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+		},
 		"domexception": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
@@ -304,10 +511,32 @@
 				}
 			}
 		},
+		"domhandler": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"requires": {
+				"domelementtype": "1"
+			}
+		},
 		"dompurify": {
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.14.tgz",
 			"integrity": "sha512-oqcjyCLHLjWugZ6VwK0YfmRND/DFy/CuZhdasmymMfnxbzaaQxBSA1ATZIXWESGDj/nvq1vKLmRa7rTdbGgrmQ=="
+		},
+		"domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"requires": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
+		"dotenv": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+			"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
 		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
@@ -317,6 +546,11 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
+		},
+		"ellipsize": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ellipsize/-/ellipsize-0.1.0.tgz",
+			"integrity": "sha1-nUNoLUS5GtFuvYQmisEDFwplU/g="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -330,6 +564,11 @@
 			"requires": {
 				"once": "^1.4.0"
 			}
+		},
+		"entities": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
 		"escodegen": {
 			"version": "1.14.3",
@@ -489,12 +728,38 @@
 				"har-schema": "^2.0.0"
 			}
 		},
+		"heap": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+			"integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
+		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
 			"integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
 			"requires": {
 				"whatwg-encoding": "^1.0.5"
+			}
+		},
+		"htmlparser2": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+			"requires": {
+				"domelementtype": "^1.3.1",
+				"domhandler": "^2.3.0",
+				"domutils": "^1.5.1",
+				"entities": "^1.1.1",
+				"inherits": "^2.0.1",
+				"readable-stream": "^3.1.1"
+			}
+		},
+		"http-headers": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/http-headers/-/http-headers-3.0.2.tgz",
+			"integrity": "sha512-87E1I+2Wg4dxxz4rcxElo3dxO/w1ZtgL1yA0Sb6vH3qU16vRKq1NjWQv9SCY3ly2OQROcoxHZOUpmelS+k6wOw==",
+			"requires": {
+				"next-line": "^1.1.0"
 			}
 		},
 		"http-signature": {
@@ -682,6 +947,11 @@
 				}
 			}
 		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+		},
 		"levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -711,6 +981,66 @@
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+		},
+		"lodash.assignin": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+			"integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
+		},
+		"lodash.bind": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+			"integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU="
+		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
+		"lodash.filter": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+			"integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4="
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+		},
+		"lodash.foreach": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+			"integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+		},
+		"lodash.map": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+			"integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+		},
+		"lodash.merge": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+		},
+		"lodash.pick": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+			"integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+		},
+		"lodash.reduce": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+			"integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs="
+		},
+		"lodash.reject": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+			"integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU="
+		},
+		"lodash.some": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+			"integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
 		},
 		"lodash.sortby": {
 			"version": "4.7.0",
@@ -748,10 +1078,33 @@
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
 		},
+		"moment-parseformat": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/moment-parseformat/-/moment-parseformat-3.0.0.tgz",
+			"integrity": "sha512-dVgXe6b6DLnv4CHG7a1zUe5mSXaIZ3c6lSHm/EKeVeQI2/4pwe0VRde8OyoCE1Ro2lKT5P6uT9JElF7KDLV+jw=="
+		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"next-line": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-line/-/next-line-1.1.0.tgz",
+			"integrity": "sha1-/K5XhTBStqm66CCOQN19PC0wRgM="
+		},
+		"node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+		},
+		"nth-check": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+			"integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+			"requires": {
+				"boolbase": "~1.0.0"
+			}
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -840,6 +1193,61 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
+		},
+		"postman-request": {
+			"version": "2.88.1-postman.25",
+			"resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.25.tgz",
+			"integrity": "sha512-J2bsUOVLBg1BXZAfWawwqhW/de30fhUvmpQd/SgOPyAiE6dAgs7LSuHMegt+RzpSLUajRFpU0/2iU4EASttZcQ==",
+			"requires": {
+				"@postman/form-data": "~3.1.0",
+				"@postman/tunnel-agent": "^0.6.3",
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.8.0",
+				"brotli": "~1.3.2",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.6",
+				"extend": "~3.0.2",
+				"forever-agent": "~0.6.1",
+				"har-validator": "~5.1.3",
+				"http-signature": "~1.3.1",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.19",
+				"oauth-sign": "~0.9.0",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.2",
+				"safe-buffer": "^5.1.2",
+				"stream-length": "^1.0.2",
+				"tough-cookie": "~2.5.0",
+				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"http-signature": {
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.4.tgz",
+					"integrity": "sha512-CbG3io8gUSIxNNSgq+XMjgpTMzAeVRipxVXjuGrDhH5M1a2kZ03w20s8FCLR1NjnnJj10KbvabvckmtQcYNb9g==",
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^1.2.2",
+						"sshpk": "^1.14.1"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"requires": {
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				}
+			}
+		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -901,6 +1309,11 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
 		},
+		"querystring": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+		},
 		"readability-extractor": {
 			"version": "git+https://github.com/pirate/readability-extractor.git#0098f142b0a015c8c90766d3b74d9eb6fb7b7e6a",
 			"from": "git+https://github.com/pirate/readability-extractor.git",
@@ -919,6 +1332,11 @@
 				"string_decoder": "^1.1.1",
 				"util-deprecate": "^1.0.1"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
 		},
 		"request": {
 			"version": "2.88.2",
@@ -947,6 +1365,33 @@
 				"uuid": "^3.3.2"
 			},
 			"dependencies": {
+				"tough-cookie": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"requires": {
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				}
+			}
+		},
+		"request-promise": {
+			"version": "4.2.6",
+			"resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.6.tgz",
+			"integrity": "sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==",
+			"requires": {
+				"bluebird": "^3.5.0",
+				"request-promise-core": "1.1.4",
+				"stealthy-require": "^1.1.1",
+				"tough-cookie": "^2.3.3"
+			},
+			"dependencies": {
+				"bluebird": {
+					"version": "3.7.2",
+					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+				},
 				"tough-cookie": {
 					"version": "2.5.0",
 					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -1015,6 +1460,11 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+		},
 		"saxes": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -1058,13 +1508,12 @@
 			"from": "git+https://github.com/gildas-lormeau/SingleFile.git",
 			"requires": {
 				"file-url": "^3.0.0",
-				"iconv-lite": "^0.5.2",
-				"jsdom": "^16.3.0",
-				"puppeteer-core": "^3.0.4",
-				"request-promise-native": "1.0.8",
+				"iconv-lite": "^0.6.2",
+				"jsdom": "^16.4.0",
+				"puppeteer-core": "^5.3.0",
 				"selenium-webdriver": "4.0.0-alpha.7",
 				"strong-data-uri": "^1.0.6",
-				"yargs": "^15.4.1"
+				"yargs": "^16.0.3"
 			},
 			"dependencies": {
 				"iconv-lite": {
@@ -1130,6 +1579,19 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
 			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+		},
+		"stream-length": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz",
+			"integrity": "sha1-gnfzy+5JpNqrz9tOL0qbXp8snwA=",
+			"requires": {
+				"bluebird": "^2.6.2"
+			}
+		},
+		"string-direction": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/string-direction/-/string-direction-0.1.2.tgz",
+			"integrity": "sha1-PYRT5ydKLkShQrPchEnftk2a3jo="
 		},
 		"string-width": {
 			"version": "4.2.0",
@@ -1237,6 +1699,171 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"turndown": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/turndown/-/turndown-5.0.3.tgz",
+			"integrity": "sha512-popfGXEiedpq6F5saRIAThKxq/bbEPVFnsDnUdjaDGIre9f3/OL9Yi/yPbPcZ7RYUDpekghr666bBfZPrwNnhQ==",
+			"requires": {
+				"jsdom": "^11.9.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.4",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+					"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+				},
+				"acorn-globals": {
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+					"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
+					"requires": {
+						"acorn": "^6.0.1",
+						"acorn-walk": "^6.0.1"
+					},
+					"dependencies": {
+						"acorn": {
+							"version": "6.4.1",
+							"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+							"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+						}
+					}
+				},
+				"acorn-walk": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+					"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+				},
+				"cssom": {
+					"version": "0.3.8",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+				},
+				"cssstyle": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+					"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+					"requires": {
+						"cssom": "0.3.x"
+					}
+				},
+				"data-urls": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+					"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+					"requires": {
+						"abab": "^2.0.0",
+						"whatwg-mimetype": "^2.2.0",
+						"whatwg-url": "^7.0.0"
+					},
+					"dependencies": {
+						"whatwg-url": {
+							"version": "7.1.0",
+							"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+							"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+							"requires": {
+								"lodash.sortby": "^4.7.0",
+								"tr46": "^1.0.1",
+								"webidl-conversions": "^4.0.2"
+							}
+						}
+					}
+				},
+				"domexception": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+					"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+					"requires": {
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"html-encoding-sniffer": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+					"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+					"requires": {
+						"whatwg-encoding": "^1.0.1"
+					}
+				},
+				"jsdom": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+					"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+					"requires": {
+						"abab": "^2.0.0",
+						"acorn": "^5.5.3",
+						"acorn-globals": "^4.1.0",
+						"array-equal": "^1.0.0",
+						"cssom": ">= 0.3.2 < 0.4.0",
+						"cssstyle": "^1.0.0",
+						"data-urls": "^1.0.0",
+						"domexception": "^1.0.1",
+						"escodegen": "^1.9.1",
+						"html-encoding-sniffer": "^1.0.2",
+						"left-pad": "^1.3.0",
+						"nwsapi": "^2.0.7",
+						"parse5": "4.0.0",
+						"pn": "^1.1.0",
+						"request": "^2.87.0",
+						"request-promise-native": "^1.0.5",
+						"sax": "^1.2.4",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^2.3.4",
+						"w3c-hr-time": "^1.0.1",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.3",
+						"whatwg-mimetype": "^2.1.0",
+						"whatwg-url": "^6.4.1",
+						"ws": "^5.2.0",
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"parse5": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+				},
+				"tough-cookie": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"requires": {
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				},
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"webidl-conversions": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+					"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
+				},
+				"whatwg-url": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				},
+				"ws": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+					"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
+			}
+		},
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -1267,6 +1894,22 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"url": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+			"requires": {
+				"punycode": "1.3.2",
+				"querystring": "0.2.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				}
+			}
+		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1276,6 +1919,11 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+		},
+		"valid-url": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+			"integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -1360,6 +2008,14 @@
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
 			"integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+		},
+		"wuzzy": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/wuzzy/-/wuzzy-0.1.6.tgz",
+			"integrity": "sha512-x1lDcj0VvzJ1ygDpd9LWMnQVei6gEkUbCcZUG8TPnXhlPbaQWQa32ab/6xbm/samxJ2T3Y2+P3xHeeQIAcEvqQ==",
+			"requires": {
+				"lodash": "^4.17.15"
+			}
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "readability-extractor": "./node_modules/.bin/readability-extractor"
   },
   "dependencies": {
+    "@postlight/mercury-parser": "^2.2.0",
     "readability-extractor": "git+https://github.com/pirate/readability-extractor.git",
     "single-file": "git+https://github.com/gildas-lormeau/SingleFile.git"
   }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -16,6 +16,7 @@ def disable_extractors_dict():
         "USE_WGET": "false",
         "USE_SINGLEFILE": "false",
         "USE_READABILITY": "false",
+        "USE_MERCURY": "false",
         "SAVE_PDF": "false",
         "SAVE_SCREENSHOT": "false",
         "SAVE_DOM": "false",

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -30,6 +30,14 @@ def test_readability_works(tmp_path, process, disable_extractors_dict):
     output_file = archived_item_path / "readability" / "content.html"
     assert output_file.exists()
 
+def test_mercury_works(tmp_path, process, disable_extractors_dict):
+    disable_extractors_dict.update({"USE_MERCURY": "true"})
+    add_process = subprocess.run(['archivebox', 'add', 'http://127.0.0.1:8080/static/example.com.html'],
+                                  capture_output=True, env=disable_extractors_dict)
+    archived_item_path = list(tmp_path.glob("archive/**/*"))[0]
+    output_file = archived_item_path / "mercury" / "content.html"
+    assert output_file.exists()
+
 def test_readability_works_with_wget(tmp_path, process, disable_extractors_dict):
     disable_extractors_dict.update({"USE_READABILITY": "true", "USE_WGET": "true"})
     add_process = subprocess.run(['archivebox', 'add', 'http://127.0.0.1:8080/static/example.com.html'],


### PR DESCRIPTION
# Summary

This PR add [mercury-parser](https://github.com/postlight/mercury-parser) as a backend engine to extract meaningful content from HTML, as an alternative to Readability.

> Mercury Parser powers the Mercury AMP Converter and Mercury Reader, a Chrome extension that removes ads and distractions, leaving only text and images for a beautiful reading view on any site.

mercury parser is also used by [Newsblur](https://github.com/samuelclay/NewsBlur), my favorite RSS Reader 😄 

# Changes these areas

- [ ] Bugfixes
- [x] Feature behavior
- [ ] Command line interface
- [x] Configuration options
- [ ] Internal architecture
- [x] Archived data layout on disk

# Motivation

I'm trying to archive this article. https://bbs.pediy.com/thread-229215.htm

Readability could only extract the last code block inside this article.

![image](https://user-images.githubusercontent.com/2762704/93863908-b3fbcf00-fcf6-11ea-945b-73d0f493e6c2.png)

![image](https://user-images.githubusercontent.com/2762704/93863973-cd9d1680-fcf6-11ea-8c72-5ee98b46a975.png)

Mercury Parser is able to extract the whole content

![image](https://user-images.githubusercontent.com/2762704/93864049-e9082180-fcf6-11ea-8a04-2b472b79d19b.png)

