### PR TITLE
Oneshot fix

### DIFF
--- a/archivebox/extractors/__init__.py
+++ b/archivebox/extractors/__init__.py
@@ -58,7 +58,7 @@ def get_default_archive_methods():
 def ignore_methods(to_ignore: List[str]):
     ARCHIVE_METHODS = get_default_archive_methods()
     methods = filter(lambda x: x[0] not in to_ignore, ARCHIVE_METHODS)
-    methods = map(lambda x: x[1], methods)
+    methods = map(lambda x: x[0], methods)
     return list(methods)
 
 @enforce_types

--- a/tests/test_oneshot.py
+++ b/tests/test_oneshot.py
@@ -8,10 +8,12 @@ def test_oneshot_command_exists(tmp_path, disable_extractors_dict):
     assert not "invalid choice: 'oneshot'" in process.stderr.decode("utf-8")
 
 def test_oneshot_commad_saves_page_in_right_folder(tmp_path, disable_extractors_dict):
+    disable_extractors_dict.update({"SAVE_DOM": "true"})
     process = subprocess.run(["archivebox", "oneshot", f"--out-dir={tmp_path}", "http://127.0.0.1:8080/static/example.com.html"],
                               capture_output=True, env=disable_extractors_dict)
     items = ' '.join([str(x) for x in tmp_path.iterdir()])
     current_path = ' '.join([str(x) for x in Path.cwd().iterdir()])
     assert "index.json" in items
     assert not "index.sqlite3" in current_path
+    assert "output.html" in items
     


### PR DESCRIPTION
# Summary

The oneshot command was not working after some internal list was changed. This PR makes it functional again, and adds a test to prevent it from happening again.

**Related issues: #484 

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

