### PR TITLE
fix: Wget absolute path generating issues

### DIFF
--- a/archivebox/extractors/wget.py
+++ b/archivebox/extractors/wget.py
@@ -179,7 +179,7 @@ def wget_output_path(link: Link) -> Optional[str]:
                     if re.search(".+\\.[Ss]?[Hh][Tt][Mm][Ll]?$", str(f), re.I | re.M)
                 ]
                 if html_files:
-                    return str(html_files[0])
+                    return str(html_files[0].relative_to(link.link_dir))
 
         # Move up one directory level
         search_dir = search_dir.parent

--- a/archivebox/themes/legacy/main_index_row.html
+++ b/archivebox/themes/legacy/main_index_row.html
@@ -2,7 +2,7 @@
     <td title="$timestamp">$bookmarked_date</td>
     <td class="title-col">
         <a href="$archive_path/index.html" class="link-url"><img src="$favicon_url" class="link-favicon" decoding="async"></a>
-        <a href="$wget_url" title="$title">
+        <a href="$archive_path/$wget_url" title="$title">
             <span data-title-for="$url" data-archived="$is_archived">$title</span>
             <small style="float:right">$tags</small>
         </a>


### PR DESCRIPTION

# Summary

Makes sure that the path calculated for `wget` is relative to `link.link_dir`

**Related issues: #483 

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Archived data layout on disk

