### PR TITLE
feat: Remove index.json and index.html generation

### DIFF
--- a/archivebox/index/__init__.py
+++ b/archivebox/index/__init__.py
@@ -22,7 +22,6 @@ from ..config import (
     ARCHIVE_DIR_NAME,
     SQL_INDEX_FILENAME,
     JSON_INDEX_FILENAME,
-    HTML_INDEX_FILENAME,
     OUTPUT_DIR,
     TIMEOUT,
     URL_BLACKLIST_PTN,
@@ -41,11 +40,9 @@ from ..logging_util import (
 
 from .schema import Link, ArchiveResult
 from .html import (
-    write_html_main_index,
     write_html_link_details,
 )
 from .json import (
-    write_json_main_index,
     parse_json_link_details, 
     write_json_link_details,
 )

--- a/archivebox/index/__init__.py
+++ b/archivebox/index/__init__.py
@@ -225,7 +225,7 @@ def timed_index_update(out_path: Path):
 
 @enforce_types
 def write_main_index(links: List[Link], out_dir: Path=OUTPUT_DIR, finished: bool=False) -> None:
-    """create index.html file for a given list of links"""
+    """Writes links to sqlite3 file for a given list of links"""
 
     log_indexing_process_started(len(links))
 
@@ -234,8 +234,6 @@ def write_main_index(links: List[Link], out_dir: Path=OUTPUT_DIR, finished: bool
             write_sql_main_index(links, out_dir=out_dir)
             os.chmod(out_dir / SQL_INDEX_FILENAME, int(OUTPUT_PERMISSIONS, base=8)) # set here because we don't write it with atomic writes
 
-        if finished:
-            write_static_index(links, out_dir=out_dir)
     except (KeyboardInterrupt, SystemExit):
         stderr('[!] Warning: Still writing index to disk...', color='lightyellow')
         stderr('    Run archivebox init to fix any inconsisntencies from an ungraceful exit.')
@@ -245,13 +243,6 @@ def write_main_index(links: List[Link], out_dir: Path=OUTPUT_DIR, finished: bool
         raise SystemExit(0)
 
     log_indexing_process_finished()
-
-@enforce_types
-def write_static_index(links: List[Link], out_dir: Path=OUTPUT_DIR) -> None:
-    with timed_index_update(out_dir / JSON_INDEX_FILENAME):
-        write_json_main_index(links)
-    with timed_index_update(out_dir / HTML_INDEX_FILENAME):
-        write_html_main_index(links, out_dir=out_dir, finished=True)
 
 @enforce_types
 def get_empty_snapshot_queryset(out_dir: Path=OUTPUT_DIR):

--- a/archivebox/logging_util.py
+++ b/archivebox/logging_util.py
@@ -264,8 +264,8 @@ def log_archiving_paused(num_links: int, idx: int, timestamp: str):
         total=num_links,
     ))
     print()
-    print('    {lightred}Hint:{reset} To view your archive index, open:'.format(**ANSI))
-    print('        {}/{}'.format(OUTPUT_DIR, HTML_INDEX_FILENAME))
+    print('    {lightred}Hint:{reset} To view your archive index, run:'.format(**ANSI))
+    print('        archivebox server  # then visit http://127.0.0.1:8000')
     print('    Continue archiving where you left off by running:')
     print('        archivebox update --resume={}'.format(timestamp))
 
@@ -291,8 +291,8 @@ def log_archiving_finished(num_links: int):
     print('    - {} links updated'.format(_LAST_RUN_STATS.succeeded + _LAST_RUN_STATS.failed))
     print('    - {} links had errors'.format(_LAST_RUN_STATS.failed))
     print()
-    print('    {lightred}Hint:{reset} To view your archive index, open:'.format(**ANSI))
-    print('        {}/{}'.format(OUTPUT_DIR, HTML_INDEX_FILENAME))
+    print('    {lightred}Hint:{reset} To view your archive index, run:'.format(**ANSI))
+    print('        archivebox server  # then visit http://127.0.0.1:8000')
     print('    Or run the built-in webserver:')
     print('        archivebox server')
 

--- a/archivebox/logging_util.py
+++ b/archivebox/logging_util.py
@@ -24,9 +24,7 @@ from .config import (
     ANSI,
     IS_TTY,
     TERM_WIDTH,
-    OUTPUT_DIR,
     SOURCES_DIR_NAME,
-    HTML_INDEX_FILENAME,
     stderr,
 )
 

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -31,7 +31,6 @@ from .index import (
     parse_links_from_source,
     dedupe_links,
     write_main_index,
-    write_static_index,
     snapshot_filter,
     get_indexed_folders,
     get_archived_folders,
@@ -561,10 +560,7 @@ def add(urls: Union[str, List[str]],
         archive_links(imported_links, overwrite=True, out_dir=out_dir)
     elif new_links:
         archive_links(new_links, overwrite=False, out_dir=out_dir)
-    else:
-        return all_links
     
-    write_static_index([link.as_link_with_details() for link in all_links], out_dir=out_dir)
     return all_links
 
 @enforce_types
@@ -641,7 +637,6 @@ def remove(filter_str: Optional[str]=None,
 
     remove_from_sql_main_index(snapshots=snapshots, out_dir=out_dir)
     all_snapshots = load_main_index(out_dir=out_dir)
-    write_static_index([link.as_link_with_details() for link in all_snapshots], out_dir=out_dir)
     log_removal_finished(all_snapshots.count(), to_remove)
     
     return all_snapshots
@@ -698,7 +693,6 @@ def update(resume: Optional[float]=None,
 
     # Step 4: Re-write links index with updated titles, icons, and resources
     all_links = load_main_index(out_dir=out_dir)
-    write_static_index([link.as_link_with_details() for link in all_links], out_dir=out_dir)
     return all_links
 
 @enforce_types

--- a/archivebox/main.py
+++ b/archivebox/main.py
@@ -4,6 +4,7 @@ import os
 import sys
 import shutil
 from pathlib import Path
+from datetime import date
 
 from typing import Dict, List, Optional, Iterable, IO, Union
 from crontab import CronTab, CronSlices
@@ -386,6 +387,15 @@ def init(force: bool=False, out_dir: Path=OUTPUT_DIR) -> None:
     print()
     print('    For more usage and examples, run:')
     print('        archivebox help')
+
+    json_index = Path(out_dir) / JSON_INDEX_FILENAME
+    html_index = Path(out_dir) / HTML_INDEX_FILENAME
+    index_name = f"{date.today()}_index_old"
+    if json_index.exists():
+        json_index.rename(f"{index_name}.json")
+    if html_index.exists():
+        html_index.rename(f"{index_name}.html")
+
 
 
 @enforce_types

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -32,9 +32,10 @@ def test_add_link(tmp_path, process, disable_extractors_dict):
         output_json = json.load(f)
     assert "Example Domain" == output_json['history']['title'][0]['output']
 
-    with open(tmp_path / "index.html", "r") as f:
+    with open(archived_item_path / "index.html", "r") as f:
         output_html = f.read()
     assert "Example Domain" in output_html
+
 
 def test_add_link_support_stdin(tmp_path, process, disable_extractors_dict):
     disable_extractors_dict.update({"USE_WGET": "true"})
@@ -51,7 +52,7 @@ def test_add_link_support_stdin(tmp_path, process, disable_extractors_dict):
     assert "Example Domain" == output_json['history']['title'][0]['output']
 
 def test_correct_permissions_output_folder(tmp_path, process):
-    index_files = ['index.json', 'index.html', 'index.sqlite3', 'archive']
+    index_files = ['index.sqlite3', 'archive']
     for file in index_files:
         file_path = tmp_path / file
         assert oct(file_path.stat().st_mode)[-3:] == OUTPUT_PERMISSIONS
@@ -113,6 +114,9 @@ def test_orphaned_folders(tmp_path, process, disable_extractors_dict):
     os.chdir(tmp_path)
     subprocess.run(['archivebox', 'add', 'http://127.0.0.1:8080/static/example.com.html'], capture_output=True,
                      env=disable_extractors_dict)
+    list_process = subprocess.run(["archivebox", "list", "--json", "--with-headers"], capture_output=True)
+    with open(tmp_path / "index.json", "wb") as f:
+        f.write(list_process.stdout)
     conn = sqlite3.connect("index.sqlite3")
     c = conn.cursor()
     c.execute("DELETE from core_snapshot")

--- a/tests/test_title.py
+++ b/tests/test_title.py
@@ -6,10 +6,8 @@ def test_title_is_htmlencoded_in_index_html(tmp_path, process, disable_extractor
     Unencoded content should not be rendered as it facilitates xss injections
     and breaks the layout.
     """
-    add_process = subprocess.run(['archivebox', 'add', 'http://localhost:8080/static/title_with_html.com.html'],
+    subprocess.run(['archivebox', 'add', 'http://localhost:8080/static/title_with_html.com.html'],
                                  capture_output=True, env=disable_extractors_dict)
+    list_process = subprocess.run(["archivebox", "list", "--html"], capture_output=True)
 
-    with open(tmp_path / "index.html", "r") as f:
-        output_html = f.read()
-
-    assert "<textarea>" not in output_html
+    assert "<textarea>" not in list_process.stdout.decode("utf-8")


### PR DESCRIPTION
# Summary

At the end of the `cli` commands (add, remove, etc) the json and html indexes were still being generated. This is a slow process dependent on the number of archived links (size of the archive). This PR removes that generation, as they can be generated on demand using the `archivebox list` command.

**Related issues: #461

# Changes these areas

- [ ] Bugfixes
- [X] Feature behavior
- [X] Command line interface
- [ ] Configuration options
- [X] Internal architecture
- [X] Archived data layout on disk
