### PR TITLE
fix: CHROME_USER_DATA_DIR 

### DIFF
--- a/archivebox/config/__init__.py
+++ b/archivebox/config/__init__.py
@@ -868,7 +868,7 @@ def check_system_config(config: ConfigDict=CONFIG) -> None:
             stderr('    Make sure you set it to a Chrome user data directory containing a Default profile folder.')
             stderr('    For more info see:')
             stderr('        https://github.com/pirate/ArchiveBox/wiki/Configuration#CHROME_USER_DATA_DIR')
-            if 'Default' in config['CHROME_USER_DATA_DIR']:
+            if 'Default' in str(config['CHROME_USER_DATA_DIR']):
                 stderr()
                 stderr('    Try removing /Default from the end e.g.:')
                 stderr('        CHROME_USER_DATA_DIR="{}"'.format(config['CHROME_USER_DATA_DIR'].split('/Default')[0]))


### PR DESCRIPTION
# Summary
`archivebox config --set CHROME_USER_DATA_DIR="./test"` is causing an error after the update to posix paths. It raises:

```
   if 'Default' in config['CHROME_USER_DATA_DIR']:
TypeError: argument of type 'PosixPath' is not iterable
```

# Related issues
#516 

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
