### PR TITLE
fix: Move wheel in setup.py to avoid wheel building issue

### DIFF
--- a/archivebox/core/settings.py
+++ b/archivebox/core/settings.py
@@ -25,7 +25,6 @@ IS_SHELL = 'shell' in sys.argv[:3] or 'shell_plus' in sys.argv[:3]
 ### Django Core Settings
 ################################################################################
 
-DEBUG = True
 WSGI_APPLICATION = 'core.wsgi.application'
 ROOT_URLCONF = 'core.urls'
 

--- a/archivebox/extractors/mercury.py
+++ b/archivebox/extractors/mercury.py
@@ -3,7 +3,7 @@ __package__ = 'archivebox.extractors'
 from pathlib import Path
 
 from subprocess import CompletedProcess
-from typing import Optional, Tuple, List
+from typing import Optional, List
 import json
 
 from ..index.schema import Link, ArchiveResult, ArchiveError

--- a/archivebox/logging_util.py
+++ b/archivebox/logging_util.py
@@ -4,7 +4,6 @@ import re
 import os
 import sys
 import time
-import platform
 import argparse
 from math import log
 from multiprocessing import Process

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ setuptools.setup(
     url=REPO_URL,
     project_urls=PROJECT_URLS,
     python_requires=">=3.7",
+    setup_requires=[
+        "wheel",
+    ],
     install_requires=[
         "requests==2.24.0",
         "atomicwrites==1.4.0",
@@ -67,7 +70,6 @@ setuptools.setup(
     extras_require={
         'dev': [
             "setuptools",
-            "wheel",
             "twine",
             "flake8",
             "ipdb",


### PR DESCRIPTION
# Summary
Move `wheel` so it is installed before pip tries to build the project's wheel.

# Related issues

#521

# Changes these areas

- [X] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
