### PR TITLE
Fixed docker-compose.yml url

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ a headless browser runtime, a full webserver, and CLI interface.
 # docker-compose run archivebox <command> [args]
 
 mkdir archivebox && cd archivebox
-wget 'https://github.com/pirate/ArchiveBox/blob/master/docker-compose.yml'
+wget 'https://raw.githubusercontent.com/pirate/ArchiveBox/master/docker-compose.yml'
 docker-compose run archivebox init
 docker-compose run archivebox add 'https://example.com'
 docker-compose run archivebox manage createsuperuser


### PR DESCRIPTION
# Summary

This PR fixes the URL for the `docker-compose.yml` configuration file. Previous link downloaded the entire github editor webpage, throwing syntax errors when trying to install via Docker. 

# Related issues

#523 

# Changes these areas

- [ ] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
