### PR TITLE
hotfix: Fixes 500 error on Admin search

### DIFF
--- a/archivebox/core/admin.py
+++ b/archivebox/core/admin.py
@@ -86,7 +86,7 @@ class SnapshotAdmin(admin.ModelAdmin):
     list_display = ('added', 'title_str', 'url_str', 'files', 'size')
     sort_fields = ('title_str', 'url_str', 'added')
     readonly_fields = ('id', 'url', 'timestamp', 'num_outputs', 'is_archived', 'url_hash', 'added', 'updated')
-    search_fields = ('url', 'timestamp', 'title', 'tags')
+    search_fields = ['url', 'timestamp', 'title', 'tags__name']
     fields = (*readonly_fields, 'title', 'tags')
     list_filter = ('added', 'updated', 'tags')
     ordering = ['-added']


### PR DESCRIPTION
# Summary

The class `SnapshotAdmin` `search_fields` includes the `tags` `ManyToMany` field causing a
```
django.core.exceptions.FieldError: Related Field got invalid lookup: icontains error.
```
A related search field `tags__name` should be used.

# Related issues


# Changes these areas

- [x] Bugfixes
- [ ] Feature behavior
- [ ] Command line interface
- [ ] Configuration options
- [ ] Internal architecture
- [ ] Snapshot data layout on disk
