### PR TITLE
Create a Workflow for publishing ARM Docker Images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,64 @@
+name: Docker Buildx and Push
+
+on:
+  schedule:
+    # 00:00 UTC every day
+    - cron:  '0 0 * * *'
+  workflow_dispatch:
+  push:
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      -
+         name: Docker Login
+         uses: docker/login-action@v1
+         with:
+           username: ${{ secrets.DockerUsername }}
+           password: ${{ secrets.DockerPassword }}
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          install: true
+      -
+        name: Builder instance name
+        run: echo ${{ steps.buildx.outputs.name }}
+      -
+        name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - 
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: |
+            ${{ secrets.DockerUsername }}/${{ secrets.DockerRepository }}:latest
+            ${{ secrets.DockerUsername }}/${{ secrets.DockerRepository }}:${{ github.sha }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/arm64,linux/arm/v7
+      -
+        name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,6 @@
 name: Docker Buildx and Push
 
 on:
-  schedule:
-    # 00:00 UTC every day
-    - cron:  '0 0 * * *'
   workflow_dispatch:
   push:
 


### PR DESCRIPTION
# Summary
Creates a Github Actions workflow for creating and publishing Docker images for the ARM CPU architecture (currently arm64 and armv7) on each push to the repository. This enables, among other things, one to directly run the published image on a Raspberry Pi.

You can see the build history in my branch and see the pushed result [in my Docker Hub repo](https://hub.docker.com/r/chrismeller/archivebox).

This workflow could be expanded to include the existing (presumably manually-built) Docker images that are published for amd64 simply by adding it to the list in the "platforms" parameter at the end of the "Build and push" step.

# Related issues

#534, #407, #78

# Changes these areas
Changes no areas within the code, just adds the workflow template.

# Additional Setup Steps Required
In order for this to run successfully, you'll need to create several secrets (Repo Settings -> Secrets):

- DockerUsername - Your Docker Hub username (nikisweeting). This is used for logging in as well as tagging/pushing the image.
- DockerPassword - A Personal Access Token generated from your Docker Hub account. (Name at the top -> Account Settings -> Security -> New Access Token)
- DockerRepository - Your Docker Hub repository name (archivebox). This is used purely for tagging/pushing the image.
